### PR TITLE
Add Godot, fix VRM, add Unity fingers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize EOL for all files that Git considers text files.
+* text=auto eol=lf

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This framework provides synthesis-based solutions through comprehensive intermed
 ### Validate each of the format descriptions:
 
 - [ ] OpenUSD - Pixar Universal Scene Description skeletal framework
-- [ ] VRM - VRoid humanoid avatar specification  
+- [ ] VRM - VRoid humanoid avatar specification
 - [ ] HAnim - Web3D Consortium humanoid animation standard
 - [ ] SMPL-X - Statistical Multi-Person Linear model eXpressive
 - [ ] BVH - Biovision Hierarchy motion capture format
@@ -55,21 +55,21 @@ This framework provides synthesis-based solutions through comprehensive intermed
 
 ### Technical
 
-- [X] How should twist bones be handled in minimal target formats?
-    - **Resolved**: incorporate description into the main text.
-    - Diagrams would be good to incorporate.
-    - A twist joint (sometimes called a roll or twist bone) is a helper joint inserted along a limb — usually the upper arm, forearm, thigh, or calf — to distribute rotational deformation (especially twisting around the bone’s primary axis) more naturally across the mesh. ${Twist}_{Rotation} = {Parent}_{Rotation} * {Twist}_{Weight}$
-- [X] Should facial expression joints use standardized blendshape names?
-    - **Resolved**: In future development, we could provide guidance on how the face joints (which are pseudo-skin/muscle clusters) that they map in some manner to FACS. Specifying FACS is out of scope, but referencing it canonically is in scope.
+- [x] How should twist bones be handled in minimal target formats?
+  - **Resolved**: incorporate description into the main text.
+  - Diagrams would be good to incorporate.
+  - A twist joint (sometimes called a roll or twist bone) is a helper joint inserted along a limb — usually the upper arm, forearm, thigh, or calf — to distribute rotational deformation (especially twisting around the bone’s primary axis) more naturally across the mesh. ${Twist}_{Rotation} = {Parent}_{Rotation} * {Twist}_{Weight}$
+- [x] Should facial expression joints use standardized blendshape names?
+  - **Resolved**: In future development, we could provide guidance on how the face joints (which are pseudo-skin/muscle clusters) that they map in some manner to FACS. Specifying FACS is out of scope, but referencing it canonically is in scope.
     Facial expressions in general are going to be a combination of joints and blendshapes.
     Breaking out expressions as a future topic seems like a strong direction.
 - [ ] What constitutes acceptable quality loss during downward conversion?
 - [ ] What validation metrics best assess cross-format conversion quality?
-- [X] Should there be performance tiers for different hardware capabilities?
-    - **Resolved**: An avatar can use a cluster geometry for hierarchy (like a suit of armor), or it can be skin-cluster weighted.
-    - We can describe common techniques as informative text.
-    - Skeletal LODs define subsets of bones.
-    - The hierarchy definition can show how Skeletal subsets map to the canonical hierarchy. We could provide guidance as to common methods for delegating functionality to articulation schemes within the same hierarchy.
+- [x] Should there be performance tiers for different hardware capabilities?
+  - **Resolved**: An avatar can use a cluster geometry for hierarchy (like a suit of armor), or it can be skin-cluster weighted.
+  - We can describe common techniques as informative text.
+  - Skeletal LODs define subsets of bones.
+  - The hierarchy definition can show how Skeletal subsets map to the canonical hierarchy. We could provide guidance as to common methods for delegating functionality to articulation schemes within the same hierarchy.
 
 ### Compatiblity
 
@@ -80,13 +80,12 @@ This framework provides synthesis-based solutions through comprehensive intermed
 
 - [ ] What governance model ensures long-term framework evolution?
 
-
-
 ## License
 
 Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
 
 This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License. You are free to share and adapt this material for any purpose, even commercially, under the following terms:
+
 - **Attribution** - You must give appropriate credit and indicate if changes were made
 - **ShareAlike** - If you remix, transform, or build upon the material, you must distribute your contributions under the same license
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ This framework provides synthesis-based solutions through comprehensive intermed
 ### Validate each of the format descriptions:
 
 - [ ] OpenUSD - Pixar Universal Scene Description skeletal framework
-- [ ] VRM - VRoid humanoid avatar specification
+- [x] VRM - VRoid [humanoid avatar specification](https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0/humanoid.md)
 - [ ] HAnim - Web3D Consortium humanoid animation standard
 - [ ] SMPL-X - Statistical Multi-Person Linear model eXpressive
 - [ ] BVH - Biovision Hierarchy motion capture format
 - [ ] ASF/AMC - Acclaim motion capture format
 - [ ] Mixamo - Adobe automated animation service
 - [ ] UE Mannequin - Unreal Engine reference skeleton
-- [ ] Unity Mecanim - Unity semantic humanoid system
+- [x] Unity Mecanim - Unity semantic humanoid system
+- [x] Godot - Godot Engine [SkeletonProfileHumanoid](https://docs.godotengine.org/en/stable/classes/class_skeletonprofilehumanoid.html)
 
 ### Create Tools
 

--- a/joints.csv
+++ b/joints.csv
@@ -1,83 +1,91 @@
-CanonicalJoint,OpenUSD,BVH,ASF/AMC,VRM,HAnim,SMPL,SMPL-X,Mixamo,UEMannequin,UnityMecanim,
-Root (Parent of e.g. Hips) / -,-,-,-,-,-,-,-,-,-,-,
-Hips / Pelvis,Hips,Hips,pelvis,hips,HumanoidRoot,pelvis,pelvis,Hips,Root (Pelvis),Hips,
-Spine / LowerBack,Torso,Spine,lowerback,spine,lumbosacral,spine1,spine1,Spine,Spine_01,Spine,
-Spine / Chest,Chest,Spine1 / Spine2,upperback / thorax,chest,thorax,spine2,spine2,Spine1 / Spine2,Spine_02 / Spine_03,Chest,
-UpperChest,UpChest,-,-,upperChest,opt,-,-,-,-,UpperChest (opt),
-Neck,Neck,Neck,lowerneck,neck,neck,neck,neck,Neck,Neck_01,Neck,
-Head,Head,Head,head,head,head,head,head,Head,Head,Head,
-Jaw,,EndSite,opt,jaw,opt,opt,jaw,opt,opt,opt,
-LeftEye,LEye,EndSite,eye_l,eye_l,eyeball_l,-,LEye,opt,Eye_L,LeftEye,
-Left / Right Eyelids,L / R controls x 12,-,-,-,-,-,-,-,-,-,
-LeftEyeTwist,-,-,-,-,-,-,LEyeTwist,-,Eye_L_Twist,-,
-RightEye,REye,EndSite,eye_r,eye_r,eyeball_r,-,REye,opt,Eye_R,RightEye,
-RightEyeTwist,-,-,-,-,-,-,REyeTwist,-,Eye_R_Twist,-,
-Nose,Nose,-,-,nose,opt,-,Nose,opt,opt,-,
-Chin,Chin / LChin / RChin,-,-,chin,opt,-,Chin,opt,opt,-,
-Left / Right Ear,LEar / REar,-,-,-,-,-,-,-,-,-,
-LeftCheek,LCheek,-,-,leftCheek,opt,-,LCheek,opt,opt,-,
-RightCheek,RCheek,-,-,rightCheek,opt,-,RCheek,opt,opt,-,
-Mouth,Mouth,-,-,mouth,opt,-,Mouth,opt,opt,-,
-UpperLip,UpLip / LUpLip / RUpLip,-,-,upperLip,opt,-,UpLip,opt,opt,-,
-LowerLip,LoLip / LLoLip / RLoLip,-,-,lowerLip,opt,-,LoLip,opt,opt,-,
-LeftLipCorner,LLipCorner,-,-,leftLipCorner,opt,-,LLipCorner,opt,opt,-,
-RightLipCorner,RLipCorner,-,-,rightLipCorner,opt,-,RLipCorner,opt,opt,-,
-Brow,LBrow / Brow,-,-,brow,opt,-,LBrow / RBrow,opt,opt,-,
-LeftClavicle,LShldr,LeftShoulder,lclavicle,leftShoulder,clavicle_l,LShldr,LShldr,LeftShoulder,Clavicle_L,LeftShoulder,
-LeftUpperArm,LArm,LeftArm,lhumerus,leftUpperArm,humerus_l,LArm,LArm,LeftArm,UpperArm_L,LeftUpperArm,
-LeftLowerArm,LElbow,LeftForeArm,lradius,leftLowerArm,radius_l,LForeArm,LForeArm,LeftForeArm,LowerArm_L,LeftLowerArm,
-LeftHand,LHand,LeftHand,lwrist,leftHand,hand_l,LHand,LHand,LeftHand,Hand_L,LeftHand,
-LeftThumbProximal,LThumb,-,lthumb,leftThumbProximal,opt,-,LThumb,LThumb,opt,opt,
-LeftThumbIntermediate,LThumbMid,-,-,leftThumbIntermediate,opt,-,LThumbMid,LThumbMid,opt,opt,
-LeftThumbDistal,LThumbTip,-,-,leftThumbDistal,opt,-,LThumbTip,LThumbTip,opt,opt,
-LeftThumbTip,LThumbEnd,-,-,leftThumbTip,opt,-,LThumbEnd,LThumbEnd,opt,opt,
-LeftIndexProximal,LIndex,-,lindex,leftIndexProximal,opt,-,LIndex,LIndex,opt,opt,
-LeftIndexIntermediate,LIndexMid,-,-,leftIndexIntermediate,opt,-,LIndexMid,LIndexMid,opt,opt,
-LeftIndexDistal,LIndexTip,-,-,leftIndexDistal,opt,-,LIndexTip,LIndexTip,opt,opt,
-LeftIndexTip,LIndexEnd,-,-,leftIndexTip,opt,-,LIndexEnd,LIndexEnd,opt,opt,
-LeftMiddleProximal,LMiddle,-,-,leftMiddleProximal,opt,-,LMiddle,LMiddle,opt,opt,
-LeftMiddleIntermediate,LMiddleMid,-,lmiddle,leftMiddleIntermediate,opt,-,LMiddleMid,LMiddleMid,opt,opt,
-LeftMiddleDistal,LMiddleTip,-,-,leftMiddleDistal,opt,-,LMiddleTip,LMiddleTip,opt,opt,
-LeftMiddleTip,LMiddleEnd,-,-,leftMiddleTip,opt,-,LMiddleEnd,LMiddleEnd,opt,opt,
-LeftRingProximal,LRing,-,lring,leftRingProximal,opt,-,LRing,LRing,opt,opt,
-LeftRingIntermediate,LRingMid,-,-,leftRingIntermediate,opt,-,LRingMid,LRingMid,opt,opt,
-LeftRingDistal,LRingTip,-,-,leftRingDistal,opt,-,LRingTip,LRingTip,opt,opt,
-LeftRingTip,LRingEnd,-,-,leftRingTip,opt,-,LRingEnd,LRingEnd,opt,opt,
-LeftPinkyProximal,LPinky,-,lpinky,leftPinkyProximal,opt,-,LPinky,LPinky,opt,opt,
-LeftPinkyIntermediate,LPinkyMid,-,-,leftPinkyIntermediate,opt,-,LPinkyMid,LPinkyMid,opt,opt,
-LeftPinkyDistal,LPinkyTip,-,-,leftPinkyDistal,opt,-,LPinkyTip,LPinkyTip,opt,opt,
-LeftPinkyTip,LPinkyEnd,-,-,leftPinkyTip,opt,-,LPinkyEnd,LPinkyEnd,opt,opt,
-RightClavicle,RShldr,RightShoulder,rclavicle,rightShoulder,clavicle_r,RShldr,RShldr,RightShoulder,Clavicle_R,RightShoulder,
-RightUpperArm,RArm,RightArm,rhumerus,rightUpperArm,humerus_r,RArm,RArm,RightArm,UpperArm_R,RightUpperArm,
-RightLowerArm,RElbow,RightForeArm,rradius,rightLowerArm,radius_r,RForeArm,RForeArm,RightForeArm,LowerArm_R,RightLowerArm,
-RightHand,RHand,RightHand,rwrist,rightHand,hand_r,RHand,RHand,RightHand,Hand_R,RightHand,
-RightThumbProximal,RThumb,-,rthumb,rightThumbProximal,opt,-,RThumb,RThumb,opt,opt,
-RightThumbIntermediate,RThumbMid,-,-,rightThumbIntermediate,opt,-,RThumbMid,RThumbMid,opt,opt,
-RightThumbDistal,RThumTip,-,-,rightThumbDistal,opt,-,RThumbTip,RThumbTip,opt,opt,
-RightThumbTip,RThumEnd,-,-,rightThumbTip,opt,-,RThumbEnd,RThumbEnd,opt,opt,
-RightIndexProximal,RIndex,-,rindex,rightIndexProximal,opt,-,RIndex,RIndex,opt,opt,
-RightIndexIntermediate,RIndexMid,-,-,rightIndexIntermediate,opt,-,RIndexMid,RIndexMid,opt,opt,
-RightIndexDistal,RIndexTip,-,-,rightIndexDistal,opt,-,RIndexTip,RIndexTip,opt,opt,
-RightIndexTip,RIndexEnd,-,-,rightIndexTip,opt,-,RIndexEnd,RIndexEnd,opt,opt,
-RightMiddleProximal,RMiddle,-,rmiddle,rightMiddleProximal,opt,-,RMiddle,RMiddle,opt,opt,
-RightMiddleIntermediate,RMiddleMid,-,-,rightMiddleIntermediate,opt,-,RMiddleMid,RMiddleMid,opt,opt,
-RightMiddleDistal,RMiddleTip,-,-,rightMiddleDistal,opt,-,RMiddleTip,RMiddleTip,opt,opt,
-RightMiddleTip,RMiddleEnd,-,-,rightMiddleTip,opt,-,RMiddleEnd,RMiddleEnd,opt,opt,
-RightRingProximal,RRing,-,rring,rightRingProximal,opt,-,RRing,RRing,opt,opt,
-RightRingIntermediate,RRingMid,-,-,rightRingIntermediate,opt,-,RRingMid,RRingMid,opt,opt,
-RightRingDistal,RRingTip,-,-,rightRingDistal,opt,-,RRingTip,RRingTip,opt,opt,
-RightRingTip,RRingEnd,-,-,rightRingTip,opt,-,RRingEnd,RRingEnd,opt,opt,
-RightPinkyProximal,RPinky,-,rpinky,rightPinkyProximal,opt,-,RPinky,RPinky,opt,opt,
-RightPinkyIntermediate,RPinkyMid,-,-,rightPinkyIntermediate,opt,-,RPinkyMid,RPinkyMid,opt,opt,
-RightPinkyDistal,RPinkyTip,-,-,rightPinkyDistal,opt,-,RPinkyTip,RPinkyTip,opt,opt,
-RightPinkyTip,RPinkyEnd,-,-,rightPinkyTip,opt,-,RPinkyEnd,RPinkyEnd,opt,opt,
-LeftUpperLeg,LLeg,LeftUpLeg,lfemur,leftUpperLeg,femur_l,LThigh,LThigh,LeftUpLeg,Thigh_L,LeftUpperLeg,
-LeftLowerLeg,LKnee,LeftLeg,ltibia,leftLowerLeg,tibia_l,LLeg,LLeg,LeftLeg,Calf_L,LeftLowerLeg,
-LeftFoot,LFoot,LeftFoot,lfoot,leftFoot,foot_l,LFoot,LFoot,LeftFoot,Foot_L,LeftFoot,
-LeftToes,LToes,EndSite,ltoes,leftToes,opt,-,LeftToes,LeftToeBase,Toe_L (opt),LeftToes (opt),
-LeftTip,LTip,-,-,leftTip,opt,-,LTip,-,LeftTip (opt),,
-RightUpperLeg,RLeg,RightUpLeg,rfemur,rightUpperLeg,femur_r,RThigh,RThigh,RightUpLeg,Thigh_R,RightUpperLeg,
-RightLowerLeg,RKnee,RightLeg,rtibia,rightLowerLeg,tibia_r,RLeg,RLeg,RightLeg,Calf_R,RightLowerLeg,
-RightFoot,RFoot,RightFoot,rfoot,rightFoot,foot_r,RFoot,RFoot,RightFoot,Foot_R,RightFoot,
-RightToes,RToes,EndSite,rtoes,rightToes,opt,-,RightToeBase,Toe_R (opt),RightToes (opt),,
-RightTip,RTip,-,-,rightTip,opt,-,RTip,-,RightTip (opt),,
+CanonicalJoint,OpenUSD,BVH,ASF/AMC,VRM,HAnim,SMPL,SMPL-X,Mixamo,UEMannequin,UnityMecanim,Godot
+Root (Parent of e.g. Hips),-,-,-,root,-,-,-,-,-,-,Root
+Hips / Pelvis,Hips,Hips,pelvis,hips,HumanoidRoot,pelvis,pelvis,Hips,Root (Pelvis),Hips,Hips
+Spine / LowerBack,Torso,Spine,lowerback,spine,lumbosacral,spine1,spine1,Spine,Spine_01,Spine,Spine
+Spine / Chest,Chest,Spine1 / Spine2,upperback / thorax,chest,thorax,spine2,spine2,Spine1 / Spine2,Spine_02 / Spine_03,Chest,Chest
+UpperChest,UpChest,-,-,upperChest,opt,-,-,-,-,UpperChest (opt),UpperChest
+Neck,Neck,Neck,lowerneck,neck,neck,neck,neck,Neck,Neck_01,Neck,Neck
+Head,Head,Head,head,head,head,head,head,Head,Head,Head,Head
+Jaw,-,EndSite,opt,jaw,opt,opt,jaw,opt,opt,Jaw,Jaw
+LeftEye,LEye,EndSite,eye_l,leftEye,eyeball_l,-,LEye,opt,Eye_L,LeftEye,LeftEye
+Left / Right Eyelids,L / R controls x 12,-,-,-,-,-,-,-,-,-,-
+LeftEyeTwist,-,-,-,-,-,-,LEyeTwist,-,Eye_L_Twist,-,-
+RightEye,REye,EndSite,eye_r,rightEye,eyeball_r,-,REye,opt,Eye_R,RightEye,RightEye
+RightEyeTwist,-,-,-,-,-,-,REyeTwist,-,Eye_R_Twist,-,-
+Nose,Nose,-,-,-,opt,-,Nose,opt,opt,-,-
+Chin,Chin / LChin / RChin,-,-,-,opt,-,Chin,opt,opt,-,-
+Left / Right Ear,LEar / REar,-,-,-,-,-,-,-,-,-,-
+LeftCheek,LCheek,-,-,-,opt,-,LCheek,opt,opt,-,-
+RightCheek,RCheek,-,-,-,opt,-,RCheek,opt,opt,-,-
+Mouth,Mouth,-,-,-,opt,-,Mouth,opt,opt,-,-
+UpperLip,UpLip / LUpLip / RUpLip,-,-,-,opt,-,UpLip,opt,opt,-,-
+LowerLip,LoLip / LLoLip / RLoLip,-,-,-,opt,-,LoLip,opt,opt,-,-
+LeftLipCorner,LLipCorner,-,-,-,opt,-,LLipCorner,opt,opt,-,-
+RightLipCorner,RLipCorner,-,-,-,opt,-,RLipCorner,opt,opt,-,-
+Brow,LBrow / Brow,-,-,-,opt,-,LBrow / RBrow,opt,opt,-,-
+LeftClavicle,LShldr,LeftShoulder,lclavicle,leftShoulder,clavicle_l,LShldr,LShldr,LeftShoulder,Clavicle_L,LeftShoulder,LeftShoulder
+LeftUpperArm,LArm,LeftArm,lhumerus,leftUpperArm,humerus_l,LArm,LArm,LeftArm,UpperArm_L,LeftUpperArm,LeftUpperArm
+LeftLowerArm,LElbow,LeftForeArm,lradius,leftLowerArm,radius_l,LForeArm,LForeArm,LeftForeArm,LowerArm_L,LeftLowerArm,LeftLowerArm
+LeftHand,LHand,LeftHand,lwrist,leftHand,hand_l,LHand,LHand,LeftHand,Hand_L,LeftHand,LeftHand
+LeftThumbMetacarpal,LThumb,-,lthumb,leftThumbMetacarpal,opt,-,LThumb,LThumb,opt,LeftThumbProximal,LeftThumbMetacarpal
+LeftThumbProximal,LThumbMid,-,-,leftThumbProximal,opt,-,LThumbMid,LThumbMid,opt,LeftThumbIntermediate,LeftThumbProximal
+LeftThumbDistal,LThumbTip,-,-,leftThumbDistal,opt,-,LThumbTip,LThumbTip,opt,LeftThumbDistal,LeftThumbDistal
+LeftThumbTip,LThumbEnd,-,-,-,opt,-,LThumbEnd,LThumbEnd,opt,-,-
+LeftIndexMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+LeftIndexProximal,LIndex,-,lindex,leftIndexProximal,opt,-,LIndex,LIndex,opt,LeftIndexProximal,LeftIndexProximal
+LeftIndexIntermediate,LIndexMid,-,-,leftIndexIntermediate,opt,-,LIndexMid,LIndexMid,opt,LeftIndexIntermediate,LeftIndexIntermediate
+LeftIndexDistal,LIndexTip,-,-,leftIndexDistal,opt,-,LIndexTip,LIndexTip,opt,LeftIndexDistal,LeftIndexDistal
+LeftIndexTip,LIndexEnd,-,-,-,opt,-,LIndexEnd,LIndexEnd,opt,-,-
+LeftMiddleMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+LeftMiddleProximal,LMiddle,-,-,leftMiddleProximal,opt,-,LMiddle,LMiddle,opt,LeftMiddleProximal,LeftMiddleProximal
+LeftMiddleIntermediate,LMiddleMid,-,lmiddle,leftMiddleIntermediate,opt,-,LMiddleMid,LMiddleMid,opt,LeftMiddleIntermediate,LeftMiddleIntermediate
+LeftMiddleDistal,LMiddleTip,-,-,leftMiddleDistal,opt,-,LMiddleTip,LMiddleTip,opt,LeftMiddleDistal,LeftMiddleDistal
+LeftMiddleTip,LMiddleEnd,-,-,-,opt,-,LMiddleEnd,LMiddleEnd,opt,-,-
+LeftRingMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+LeftRingProximal,LRing,-,lring,leftRingProximal,opt,-,LRing,LRing,opt,LeftRingProximal,LeftRingProximal
+LeftRingIntermediate,LRingMid,-,-,leftRingIntermediate,opt,-,LRingMid,LRingMid,opt,LeftRingIntermediate,LeftRingIntermediate
+LeftRingDistal,LRingTip,-,-,leftRingDistal,opt,-,LRingTip,LRingTip,opt,LeftRingDistal,LeftRingDistal
+LeftRingTip,LRingEnd,-,-,-,opt,-,LRingEnd,LRingEnd,opt,-,-
+LeftPinkyMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+LeftPinkyProximal,LPinky,-,lpinky,leftLittleProximal,opt,-,LPinky,LPinky,opt,LeftLittleProximal,LeftLittleProximal
+LeftPinkyIntermediate,LPinkyMid,-,-,leftLittleIntermediate,opt,-,LPinkyMid,LPinkyMid,opt,LeftLittleIntermediate,LeftLittleIntermediate
+LeftPinkyDistal,LPinkyTip,-,-,leftLittleDistal,opt,-,LPinkyTip,LPinkyTip,opt,LeftLittleDistal,LeftLittleDistal
+LeftPinkyTip,LPinkyEnd,-,-,-,opt,-,LPinkyEnd,LPinkyEnd,opt,-,-
+RightClavicle,RShldr,RightShoulder,rclavicle,rightShoulder,clavicle_r,RShldr,RShldr,RightShoulder,Clavicle_R,RightShoulder,RightShoulder
+RightUpperArm,RArm,RightArm,rhumerus,rightUpperArm,humerus_r,RArm,RArm,RightArm,UpperArm_R,RightUpperArm,RightUpperArm
+RightLowerArm,RElbow,RightForeArm,rradius,rightLowerArm,radius_r,RForeArm,RForeArm,RightForeArm,LowerArm_R,RightLowerArm,RightLowerArm
+RightHand,RHand,RightHand,rwrist,rightHand,hand_r,RHand,RHand,RightHand,Hand_R,RightHand,RightHand
+RightThumbMetacarpal,RThumb,-,rthumb,rightThumbMetacarpal,opt,-,RThumb,RThumb,opt,RightThumbProximal,RightThumbMetacarpal
+RightThumbProximal,RThumbMid,-,-,rightThumbProximal,opt,-,RThumbMid,RThumbMid,opt,RightThumbIntermediate,RightThumbProximal
+RightThumbDistal,RThumTip,-,-,rightThumbDistal,opt,-,RThumbTip,RThumbTip,opt,RightThumbDistal,RightThumbDistal
+RightThumbTip,RThumEnd,-,-,-,opt,-,RThumbEnd,RThumbEnd,opt,-,-
+RightIndexMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+RightIndexProximal,RIndex,-,rindex,rightIndexProximal,opt,-,RIndex,RIndex,opt,RightIndexProximal,RightIndexProximal
+RightIndexIntermediate,RIndexMid,-,-,rightIndexIntermediate,opt,-,RIndexMid,RIndexMid,opt,RightIndexIntermediate,RightIndexIntermediate
+RightIndexDistal,RIndexTip,-,-,rightIndexDistal,opt,-,RIndexTip,RIndexTip,opt,RightIndexDistal,RightIndexDistal
+RightIndexTip,RIndexEnd,-,-,-,opt,-,RIndexEnd,RIndexEnd,opt,-,-
+RightMiddleMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+RightMiddleProximal,RMiddle,-,rmiddle,rightMiddleProximal,opt,-,RMiddle,RMiddle,opt,RightMiddleProximal,RightMiddleProximal
+RightMiddleIntermediate,RMiddleMid,-,-,rightMiddleIntermediate,opt,-,RMiddleMid,RMiddleMid,opt,RightMiddleIntermediate,RightMiddleIntermediate
+RightMiddleDistal,RMiddleTip,-,-,rightMiddleDistal,opt,-,RMiddleTip,RMiddleTip,opt,RightMiddleDistal,RightMiddleDistal
+RightMiddleTip,RMiddleEnd,-,-,-,opt,-,RMiddleEnd,RMiddleEnd,opt,-,-
+RightRingMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+RightRingProximal,RRing,-,rring,rightRingProximal,opt,-,RRing,RRing,opt,RightRingProximal,RightRingProximal
+RightRingIntermediate,RRingMid,-,-,rightRingIntermediate,opt,-,RRingMid,RRingMid,opt,RightRingIntermediate,RightRingIntermediate
+RightRingDistal,RRingTip,-,-,rightRingDistal,opt,-,RRingTip,RRingTip,opt,RightRingDistal,RightRingDistal
+RightRingTip,RRingEnd,-,-,-,opt,-,RRingEnd,RRingEnd,opt,-,-
+RightPinkyMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+RightPinkyProximal,RPinky,-,rpinky,rightLittleProximal,opt,-,RPinky,RPinky,opt,RightLittleProximal,RightLittleProximal
+RightPinkyIntermediate,RPinkyMid,-,-,rightLittleIntermediate,opt,-,RPinkyMid,RPinkyMid,opt,RightLittleIntermediate,RightLittleIntermediate
+RightPinkyDistal,RPinkyTip,-,-,rightLittleDistal,opt,-,RPinkyTip,RPinkyTip,opt,RightLittleDistal,RightLittleDistal
+RightPinkyTip,RPinkyEnd,-,-,-,opt,-,RPinkyEnd,RPinkyEnd,opt,-,-
+LeftUpperLeg,LLeg,LeftUpLeg,lfemur,leftUpperLeg,femur_l,LThigh,LThigh,LeftUpLeg,Thigh_L,LeftUpperLeg,LeftUpperLeg
+LeftLowerLeg,LKnee,LeftLeg,ltibia,leftLowerLeg,tibia_l,LLeg,LLeg,LeftLeg,Calf_L,LeftLowerLeg,LeftLowerLeg
+LeftFoot,LFoot,LeftFoot,lfoot,leftFoot,foot_l,LFoot,LFoot,LeftFoot,Foot_L,LeftFoot,LeftFoot
+LeftToes,LToes,EndSite,ltoes,leftToes,opt,-,LeftToes,LeftToeBase,Toe_L (opt),LeftToes (opt),LeftToes
+LeftTip,LTip,-,-,-,opt,-,LTip,-,LeftTip (opt),-,-
+RightUpperLeg,RLeg,RightUpLeg,rfemur,rightUpperLeg,femur_r,RThigh,RThigh,RightUpLeg,Thigh_R,RightUpperLeg,RightUpperLeg
+RightLowerLeg,RKnee,RightLeg,rtibia,rightLowerLeg,tibia_r,RLeg,RLeg,RightLeg,Calf_R,RightLowerLeg,RightLowerLeg
+RightFoot,RFoot,RightFoot,rfoot,rightFoot,foot_r,RFoot,RFoot,RightFoot,Foot_R,RightFoot,RightFoot
+RightToes,RToes,EndSite,rtoes,rightToes,opt,-,-,RightToeBase,Toe_R (opt),RightToes (opt),RightToes
+RightTip,RTip,-,-,-,opt,-,RTip,-,RightTip (opt),-,-

--- a/joints.csv
+++ b/joints.csv
@@ -81,6 +81,3 @@ RightLowerLeg,RKnee,RightLeg,rtibia,rightLowerLeg,tibia_r,RLeg,RLeg,RightLeg,Cal
 RightFoot,RFoot,RightFoot,rfoot,rightFoot,foot_r,RFoot,RFoot,RightFoot,Foot_R,RightFoot,
 RightToes,RToes,EndSite,rtoes,rightToes,opt,-,RightToeBase,Toe_R (opt),RightToes (opt),,
 RightTip,RTip,-,-,rightTip,opt,-,RTip,-,RightTip (opt),,
-
-
-

--- a/proposal.md
+++ b/proposal.md
@@ -165,26 +165,30 @@ Hips / Pelvis (ROOT)
 │     │              ├── LeftLowerArmTwist (opt / twist)
 │     │              └── LeftHand
 │     │                   ├── LeftThumb
+│     │                   │    ├── LeftThumbMetacarpal (opt / twist)
 │     │                   │    ├── LeftThumbProximal (opt / twist)
-│     │                   │    ├── LeftThumbIntermediate (opt / twist)
 │     │                   │    ├── LeftThumbDistal (opt / twist)
 │     │                   │    └── LeftThumbTip (opt)
 │     │                   ├── LeftIndex
+│     │                   │    ├── LeftIndexMetacarpal (opt / uncommon)
 │     │                   │    ├── LeftIndexProximal (opt / twist)
 │     │                   │    ├── LeftIndexIntermediate (opt / twist)
 │     │                   │    ├── LeftIndexDistal (opt / twist)
 │     │                   │    └── LeftIndexTip (opt)
 │     │                   ├── LeftMiddle
+│     │                   │    ├── LeftMiddleMetacarpal (opt / uncommon)
 │     │                   │    ├── LeftMiddleProximal (opt / twist)
 │     │                   │    ├── LeftMiddleIntermediate (opt / twist)
 │     │                   │    ├── LeftMiddleDistal (opt / twist)
 │     │                   │    └── LeftMiddleTip (opt)
 │     │                   ├── LeftRing
+│     │                   │    ├── LeftRingMetacarpal (opt / uncommon)
 │     │                   │    ├── LeftRingProximal (opt / twist)
 │     │                   │    ├── LeftRingIntermediate (opt / twist)
 │     │                   │    ├── LeftRingDistal (opt / twist)
 │     │                   │    └── LeftRingTip (opt)
 │     │                   └── LeftPinky
+│     │                        ├── LeftPinkyMetacarpal (opt / uncommon)
 │     │                        ├── LeftPinkyProximal (opt / twist)
 │     │                        ├── LeftPinkyIntermediate (opt / twist)
 │     │                        ├── LeftPinkyDistal (opt / twist)
@@ -196,26 +200,30 @@ Hips / Pelvis (ROOT)
 │                    ├── RightLowerArmTwist (opt / twist)
 │                    └── RightHand
 │                         ├── RightThumb
+│                         │    ├── RightThumbMetacarpal (opt / twist)
 │                         │    ├── RightThumbProximal (opt / twist)
-│                         │    ├── RightThumbIntermediate (opt / twist)
 │                         │    ├── RightThumbDistal (opt / twist)
 │                         │    └── RightThumbTip (opt)
 │                         ├── RightIndex
+│                         │    ├── RightIndexMetacarpal (opt / uncommon)
 │                         │    ├── RightIndexProximal (opt / twist)
 │                         │    ├── RightIndexIntermediate (opt / twist)
 │                         │    ├── RightIndexDistal (opt / twist)
 │                         │    └── RightIndexTip (opt)
 │                         ├── RightMiddle
+│                         │    ├── RightMiddleMetacarpal (opt / uncommon)
 │                         │    ├── RightMiddleProximal (opt / twist)
 │                         │    ├── RightMiddleIntermediate (opt / twist)
 │                         │    ├── RightMiddleDistal (opt / twist)
 │                         │    └── RightMiddleTip (opt)
 │                         ├── RightRing
+│                         │    ├── RightRingMetacarpal (opt / uncommon)
 │                         │    ├── RightRingProximal (opt / twist)
 │                         │    ├── RightRingIntermediate (opt / twist)
 │                         │    ├── RightRingDistal (opt / twist)
 │                         │    └── RightRingTip (opt)
 │                         └── RightPinky
+│                              ├── RightPinkyMetacarpal (opt / uncommon)
 │                              ├── RightPinkyProximal (opt / twist)
 │                              ├── RightPinkyIntermediate (opt / twist)
 │                              ├── RightPinkyDistal (opt / twist)

--- a/proposal.md
+++ b/proposal.md
@@ -1,8 +1,8 @@
 # Reference Canonical Skeleton Framework: A Metaverse Standards Forum Proposal for Humanoid Skeletal Interoperability
 
-**Submitted to:** Metaverse Standards Forum  
+**Submitted to:** Metaverse Standards Forum
 **Authors:** Nick Porcino
-**Date:** 2025 August 27 
+**Date:** 2025 August 27
 **Version:** 1.0
 
 ## Executive Summary
@@ -239,21 +239,27 @@ Hips / Pelvis (ROOT)
 ## Joint Classification System
 
 ### Core Joints
+
 Essential humanoid skeleton compatible with all analyzed standards. These joints must be present for valid RCSF representation:
+
 - Hips (root)
 - Spine, Chest, Neck, Head
 - Left/Right Clavicle, UpperArm, LowerArm, Hand
 - Left/Right UpperLeg, LowerLeg, Foot
 
 ### Optional Joints (opt)
+
 Joints that enhance detail but are not required for basic humanoid functionality. Optional joints enable high-fidelity representation while maintaining compatibility with simplified target formats:
+
 - UpperChest: Additional spinal articulation for enhanced torso deformation
 - Facial features: Eyes, jaw, lips, cheeks, nose, ears, brow for expression control
 - Finger segments: Detailed finger articulation beyond basic hand representation
 - Toe segments: Foot detail beyond basic foot representation
 
 ### Twist Bones (twist)
+
 Intermediate joints that improve deformation quality without altering base skeletal topology. Twist bones address limb deformation artifacts by providing additional control points along bone segments:
+
 - UpperArmTwist/LowerArmTwist: Improve arm deformation during forearm rotation
 - UpperLegTwist/LowerLegTwist: Enhance leg deformation during hip and knee articulation
 - Finger twist bones: Provide enhanced finger deformation for high-fidelity hand animation
@@ -269,11 +275,13 @@ T_world(joint) = T_world(parent) × T_local(joint)
 ```
 
 For a joint chain from root to end-effector:
+
 ```
 T_world(end) = T_root × T_joint1 × T_joint2 × ... × T_jointN
 ```
 
 Where each local transformation matrix combines translation, rotation, and scale:
+
 ```
 T_local = Translation × Rotation × Scale
 ```
@@ -290,6 +298,7 @@ T = [R11  R12  R13  Tx ]
 ```
 
 Where:
+
 - **R** is the 3×3 rotation matrix
 - **T** is the translation vector (Tx, Ty, Tz)
 - Scale is incorporated into the rotation matrix for uniform scaling
@@ -301,16 +310,19 @@ The inverse base pose represents the transformation required to convert from the
 **Base Pose Definition**: The canonical rest position where all joint rotations are zero and the skeleton assumes anatomically neutral positioning.
 
 **Inverse Base Pose Calculation**:
+
 ```
 T_inverse_base(joint) = T_base(joint)^(-1)
 ```
 
 **Application to Target Format**:
+
 ```
 T_target = T_inverse_base × T_RCSF × T_target_base
 ```
 
 This transformation sequence:
+
 1. Converts from target base pose to neutral space
 2. Applies RCSF transformations
 3. Converts to target format's expected base pose
@@ -320,11 +332,13 @@ This transformation sequence:
 #### Joint Orientation Alignment
 
 Different formats use varying local coordinate systems for joints. The RCSF uses consistent anatomical orientation:
+
 - **X-axis**: Points along bone length (distal direction)
 - **Y-axis**: Points toward anatomical "up" direction
 - **Z-axis**: Completes right-handed coordinate system
 
 When converting to target formats with different joint orientations:
+
 ```python
 def align_joint_orientation(RCSF_transform, target_orientation):
     alignment_matrix = calculate_alignment(RCSF_axes, target_axes)
@@ -334,6 +348,7 @@ def align_joint_orientation(RCSF_transform, target_orientation):
 #### Rotation Order Conversion
 
 RCSF uses XYZ Euler rotation order internally. For target formats using different orders:
+
 ```python
 def convert_rotation_order(rotation_xyz, target_order):
     # Convert to rotation matrix
@@ -355,7 +370,7 @@ def map_joint_name(canonical_joint, target_format):
     """
     mapping_row = csv_table.find_row(canonical_joint)
     target_name = mapping_row[target_format + '_column']
-    
+
     if target_name == '-' or target_name == 'opt':
         return None  # Joint not supported in target format
     elif target_name == 'EndSite':
@@ -369,6 +384,7 @@ def map_joint_name(canonical_joint, target_format):
 When target formats lack specific joints present in source data:
 
 **Optional Joint Exclusion**:
+
 ```python
 def filter_optional_joints(joint_list, target_format_capabilities):
     required_joints = get_required_joints_for_format(target_format_capabilities)
@@ -376,6 +392,7 @@ def filter_optional_joints(joint_list, target_format_capabilities):
 ```
 
 **Parent Chain Collapse**:
+
 ```python
 def collapse_missing_joints(parent_joint, missing_joint, child_joint):
     """
@@ -392,6 +409,7 @@ def collapse_missing_joints(parent_joint, missing_joint, child_joint):
 When source formats contain joints not present in RCSF canonical set:
 
 **Multiple Spine Joints**:
+
 ```python
 def map_multiple_spine_joints(spine_joints):
     """
@@ -401,8 +419,8 @@ def map_multiple_spine_joints(spine_joints):
         return {'Spine': spine_joints[0], 'Chest': spine_joints[1]}
     elif len(spine_joints) == 3:
         return {
-            'Spine': spine_joints[0], 
-            'Chest': spine_joints[1], 
+            'Spine': spine_joints[0],
+            'Chest': spine_joints[1],
             'UpperChest': spine_joints[2]
         }
     else:
@@ -411,6 +429,7 @@ def map_multiple_spine_joints(spine_joints):
 ```
 
 **Twist Bone Inference**:
+
 ```python
 def detect_twist_bones(joint_hierarchy):
     """
@@ -418,12 +437,12 @@ def detect_twist_bones(joint_hierarchy):
     """
     twist_patterns = ['twist', 'roll', 'turn', '_01', '_02']
     twist_bones = []
-    
+
     for joint in joint_hierarchy:
         if any(pattern in joint.name.lower() for pattern in twist_patterns):
             if is_intermediate_joint(joint):  # Between major joints
                 twist_bones.append(joint)
-    
+
     return twist_bones
 ```
 
@@ -432,6 +451,7 @@ def detect_twist_bones(joint_hierarchy):
 ### Anatomical Consistency Validation
 
 **Bone Length Ratio Verification**:
+
 ```python
 def validate_bone_proportions(skeleton):
     """
@@ -439,7 +459,7 @@ def validate_bone_proportions(skeleton):
     """
     ratios = calculate_bone_length_ratios(skeleton)
     anatomical_bounds = load_anthropometric_data()
-    
+
     for bone_pair, ratio in ratios.items():
         min_bound, max_bound = anatomical_bounds[bone_pair]
         if not (min_bound <= ratio <= max_bound):
@@ -447,6 +467,7 @@ def validate_bone_proportions(skeleton):
 ```
 
 **Kinematic Constraint Checking**:
+
 ```python
 def validate_joint_constraints(skeleton):
     """
@@ -463,6 +484,7 @@ def validate_joint_constraints(skeleton):
 ### Conversion Quality Metrics
 
 **Information Preservation Measurement**:
+
 ```python
 def calculate_information_preservation(source_skeleton, converted_skeleton):
     """
@@ -470,10 +492,10 @@ def calculate_information_preservation(source_skeleton, converted_skeleton):
     """
     source_joints = set(source_skeleton.joint_names)
     converted_joints = set(converted_skeleton.joint_names)
-    
+
     preserved_ratio = len(source_joints & converted_joints) / len(source_joints)
     added_ratio = len(converted_joints - source_joints) / len(source_joints)
-    
+
     return {
         'preservation_ratio': preserved_ratio,
         'enhancement_ratio': added_ratio,
@@ -482,28 +504,29 @@ def calculate_information_preservation(source_skeleton, converted_skeleton):
 ```
 
 **Animation Fidelity Assessment**:
+
 ```python
 def assess_animation_quality(original_motion, retargeted_motion):
     """
     Compare motion characteristics before and after retargeting
     """
     metrics = {}
-    
+
     # Joint angle correlation
     metrics['joint_correlation'] = calculate_joint_angle_correlation(
         original_motion, retargeted_motion
     )
-    
+
     # End-effector position accuracy
     metrics['position_error'] = calculate_end_effector_error(
         original_motion, retargeted_motion
     )
-    
+
     # Motion smoothness preservation
     metrics['smoothness_preservation'] = calculate_smoothness_metric(
         original_motion, retargeted_motion
     )
-    
+
     return metrics
 ```
 
@@ -512,6 +535,7 @@ def assess_animation_quality(original_motion, retargeted_motion):
 ### Level-of-Detail Implementation
 
 **Joint Subset Selection**:
+
 ```python
 def select_lod_joints(skeleton, target_performance_level):
     """
@@ -526,31 +550,33 @@ def select_lod_joints(skeleton, target_performance_level):
 ```
 
 **Twist Bone Optimization**:
+
 ```python
 def optimize_twist_bones(skeleton, performance_budget):
     """
     Selectively enable twist bones based on visual impact and performance cost
     """
     twist_bones = skeleton.get_twist_bones()
-    
+
     # Sort by visual impact (arms > legs > fingers)
     priority_order = sort_by_visual_impact(twist_bones)
-    
+
     enabled_twist_bones = []
     current_cost = 0
-    
+
     for twist_bone in priority_order:
         bone_cost = calculate_processing_cost(twist_bone)
         if current_cost + bone_cost <= performance_budget:
             enabled_twist_bones.append(twist_bone)
             current_cost += bone_cost
-    
+
     return enabled_twist_bones
 ```
 
 ### Error Handling and Fallback Strategies
 
 **Graceful Degradation**:
+
 ```python
 def convert_with_fallback(source_skeleton, target_format):
     try:
@@ -563,7 +589,6 @@ def convert_with_fallback(source_skeleton, target_format):
         log_conversion_error(e)
         return create_minimal_skeleton(target_format)
 ```
-
 
 ## Implementation Scope and Limitations
 
@@ -579,6 +604,7 @@ This appendix addresses **homogeneous humanoid skeleton** conversion—transform
 ### Excluded Scenarios
 
 **Heterogeneous Rig Transfer**: Conversion between fundamentally different anatomical structures (human ↔ quadruped, human ↔ mechanical robot, adult ↔ infant) requires separate approaches involving:
+
 - Anatomical topology translation
 - Proportional adaptation algorithms
 - Functional role remapping
@@ -612,8 +638,7 @@ Standards were selected to provide comprehensive coverage across three primary a
 - Motion Capture Formats
 - Real-Time Rendering Systems
 - Research and Analysis Standards
-- 
-This selection encompasses the major technical paradigms and operational contexts that drive humanoid skeletal system design across contemporary digital content production, ensuring that RCSF synthesis reflects practical industry requirements rather than theoretical completeness.
+- This selection encompasses the major technical paradigms and operational contexts that drive humanoid skeletal system design across contemporary digital content production, ensuring that RCSF synthesis reflects practical industry requirements rather than theoretical completeness.
 
 ### Analytical Framework Development
 
@@ -680,6 +705,6 @@ The complete technical analysis, including individual standard specifications, c
 The paper provides:
 
 - **Individual Standard Analysis**: Comprehensive technical specifications, architectural analysis, and operational context assessment for each of the ten analyzed standards
-- **Complete Mapping Tables**: Detailed semantic correspondence tables enabling algorithmic cross-format conversion with quality assessment capabilities  
+- **Complete Mapping Tables**: Detailed semantic correspondence tables enabling algorithmic cross-format conversion with quality assessment capabilities
 - **Conversion Algorithm Specifications**: Technical implementation guidance for automated mapping systems including heuristic strategies, validation frameworks, and performance optimization approaches
 - **Research Methodology Documentation**: Systematic analytical frameworks and evaluation criteria that support continued research and community validation of interoperability approaches

--- a/references.md
+++ b/references.md
@@ -5,8 +5,9 @@ This document lists the primary documentation sources for each skeletal format a
 ## OpenUSD (Universal Scene Description)
 
 **Official Documentation:**
+
 - UsdSkel API Documentation - https://openusd.org/dev/api/usd_skel_page_front.html
-- UsdSkel Introduction - https://openusd.org/dev/api/_usd_skel__intro.html  
+- UsdSkel Introduction - https://openusd.org/dev/api/_usd_skel__intro.html
 - UsdSkel API Introduction - https://openusd.org/dev/api/_usd_skel__a_p_i__intro.html
 - UsdSkel Schemas In-Depth - https://openusd.org/dev/api/_usd_skel__schemas.html
 - UsdSkel Schema Overview - https://openusd.org/dev/api/_usd_skel__schema_overview.html
@@ -17,12 +18,14 @@ This document lists the primary documentation sources for each skeletal format a
 ## VRM (Virtual Reality Model)
 
 **Official Documentation:**
+
 - VRM Official Website - https://vrm.dev/en/
 - VRM Consortium - https://vrm-consortium.org/en/
-- GitHub Specification Repository - https://github.com/vrm-c/vrm-specification *(referenced in search results but requires direct access)*
+- GitHub Specification Repository - https://github.com/vrm-c/vrm-specification _(referenced in search results but requires direct access)_
 - Library of Congress Format Description - https://www.loc.gov/preservation/digital/formats/fdd/fdd000564.shtml
 
 **Third-Party Documentation:**
+
 - Converting an avatar to VRM format (Community Guide) - https://gist.github.com/emilianavt/51d8399987d67544fdebfe2ebd9a5149
 - Animaze VRM Integration Documentation - https://www.animaze.us/manual/vrmavatar/vrmanimations
 
@@ -31,6 +34,7 @@ This document lists the primary documentation sources for each skeletal format a
 ## HAnim (Humanoid Animation)
 
 **Official Documentation:**
+
 - HAnim Working Group (Web3D Consortium) - https://www.web3d.org/working-groups/hanim
 - All HAnim Standards - https://www.web3d.org/new/standards/hanim
 - HAnim Architecture V2 - https://www.web3d.org/content/hanim-architecture-v2
@@ -38,7 +42,8 @@ This document lists the primary documentation sources for each skeletal format a
 - HAnim GitHub Repository - https://github.com/x3d/HumanoidAnimation
 
 **Standards Reference:**
-- ISO/IEC 19774 - Humanoid Animation (H-Anim) *(ISO standard, requires purchase)*
+
+- ISO/IEC 19774 - Humanoid Animation (H-Anim) _(ISO standard, requires purchase)_
 - ISO/IEC 19775-1 X3D Component 26 Humanoid Animation (HAnim)
 
 **Description:** HAnim supports a wide variety of articulated figures, including anatomically correct human models, incorporating haptic and kinematic interfaces in order to enable sharable skeletons, bodies and animations.
@@ -46,11 +51,13 @@ This document lists the primary documentation sources for each skeletal format a
 ## SMPL-X (Statistical Multi-Person Linear Model eXpressive)
 
 **Official Documentation:**
+
 - SMPL-X Website (MPI-IS) - https://smpl-x.is.tue.mpg.de (model downloads, licenses, and integration materials)
 - GitHub Repository: vchoutas/smplx - https://github.com/vchoutas/smplx (official implementation, parameters, installation)
 - SMPL-X Model License - https://smpl-x.is.tue.mpg.de/license (non-commercial/academic terms)
 
 **Academic Publications:**
+
 - Pavlakos et al. "Expressive Body Capture: 3D Hands, Face, and Body from a Single Image" (CVPR 2019) - https://arxiv.org/abs/1904.05866
 
 **Description:** SMPL-X extends the SMPL body model with fully articulated hands and an expressive face, enabling unified modeling of body pose, hand gestures, and facial expressions. The model supports 127 joints total (24 body + 30 hand + 51 face + 22 additional articulation).
@@ -58,6 +65,7 @@ This document lists the primary documentation sources for each skeletal format a
 ## BVH (Biovision Hierarchy)
 
 **Primary Documentation:**
+
 - Wikipedia — Biovision Hierarchy - https://en.wikipedia.org/wiki/Biovision_Hierarchy (general overview, structure, and adoption)
 - FileFormat.com — BVH File Format - https://www.fileformat.com/3d/bvh (technical description and software integration)
 - CityU Technical Reference - http://www.cs.cityu.edu.hk/~howard/Teaching/CS4185-5185-2007B/Group12/BVH.html (hierarchical structure documentation)
@@ -67,6 +75,7 @@ This document lists the primary documentation sources for each skeletal format a
 ## ASF/AMC (Acclaim Skeleton + Motion Capture Format)
 
 **Primary Documentation:**
+
 - University Format Overview - http://research.cs.wisc.edu/graphics/Courses/cs-838-1999/Jeff/ASF-AMC.html (Acclaim format skeleton + motion structure)
 - Carnegie Mellon Documentation - http://graphics.cs.cmu.edu (CMU Graphics Lab motion capture database)
 - Wikipedia - List of Motion and Gesture File Formats (ASF/AMC file pair description)
@@ -74,6 +83,7 @@ This document lists the primary documentation sources for each skeletal format a
 - Darwin 3D Academic Specification - ResearchGate (mocap file formats overview, Euler conventions)
 
 **Tool-Specific Documentation:**
+
 - Autodesk MotionBuilder Limitations - Autodesk Help (import/export quirks, SphericXYZ rotation order limitations)
 
 **Description:** ASF/AMC separates skeleton definition (.ASF) from motion data (.AMC). ASF files contain joint hierarchy, degrees of freedom, and bone lengths, while AMC files contain time-series animation data for the defined skeleton.
@@ -81,12 +91,14 @@ This document lists the primary documentation sources for each skeletal format a
 ## Mixamo
 
 **Primary Documentation:**
+
 - Mixamo Website (Adobe) - https://www.mixamo.com (Auto-Rigger, animation store, service documentation)
 - Epic Games Unreal Engine Integration - https://docs.unrealengine.com (Mixamo Content usage, animation retargeting guides)
 
 **Integration Documentation:**
+
 - Omniverse Integration Tutorials - NVIDIA Developer documentation
-- Blender Integration Guides - Community tutorials for Mixamo-to-Blender workflows  
+- Blender Integration Guides - Community tutorials for Mixamo-to-Blender workflows
 - Ready Player Me Integration - https://docs.readyplayer.me (avatar system integration with Mixamo)
 
 **Description:** Mixamo provides cloud-based auto-rigging and animation services with a standardized skeletal structure optimized for automated motion retargeting across diverse character models.
@@ -94,10 +106,12 @@ This document lists the primary documentation sources for each skeletal format a
 ## UE Mannequin (Unreal Engine)
 
 **Primary Documentation:**
+
 - Unreal Engine Documentation - https://docs.unrealengine.com/skeletons (Skeletal hierarchy, skeleton assets, skeletal mesh assets)
 - Epic Games Developer Community - https://dev.epicgames.com (Skeletal Editor tutorials, IK setup, bone structure guides)
 
 **Community Documentation:**
+
 - Epic Games Forums - Developer community discussions on mannequin bone structure and usage
 - Reddit Community Insights - Community explanations of mannequin purpose and animation retargeting
 
@@ -106,10 +120,12 @@ This document lists the primary documentation sources for each skeletal format a
 ## Unity Mecanim
 
 **Primary Documentation:**
+
 - Unity Manual - https://docs.unity3d.com/Manual/MecanimAnimationSystem.html (Mecanim Animation System, humanoid rig setup, retargeting)
 - Unity Developer Blog - Unity blog posts on Mecanim humanoid technology and implementation details
 
-**Integration Documentation:**  
+**Integration Documentation:**
+
 - AAAnimators Tutorials - https://aaanimators.com (Unity avatar mapping, humanoid setup guides)
 - Unity Learn Platform - Official Unity tutorials on avatar definitions and humanoid mapping
 

--- a/references.md
+++ b/references.md
@@ -131,6 +131,14 @@ This document lists the primary documentation sources for each skeletal format a
 
 **Description:** Unity Mecanim provides semantic role-based humanoid animation through Avatar abstraction, enabling automatic retargeting between diverse skeletal rigs through standardized anatomical role mapping.
 
+## Godot SkeletonProfileHumanoid
+
+**Primary Documentation:**
+
+- Godot Engine Documentation - https://docs.godotengine.org/en/stable/classes/class_skeletonprofilehumanoid.html
+
+**Description:** Godot's SkeletonProfileHumanoid class defines a preset SkeletonProfile that is optimized for the human form. It contains 56 bones divided into 4 groups.
+
 ---
 
 ## Research Notes

--- a/survey.md
+++ b/survey.md
@@ -1,4 +1,3 @@
-
 # Humanoid Joint Hierarchy Standards: A Cross-Format Reference
 
 ## Overview
@@ -20,19 +19,23 @@ Humanoid skeletal systems, while varying significantly in naming conventions and
 The analysis studies nine primary standards representing the current landscape of humanoid skeletal representation:
 
 **Production Standards:**
+
 - **OpenUSD** - Pixar's Universal Scene Description production sample featuring detailed facial controls
 - **VRM** - VRoid humanoid avatar specification with its standardized 55-bone mapping
 - **Mixamo** - Adobe's animation retargeting system (BVH-compatible)
 
 **Motion Capture Formats:**
+
 - **BVH** (Biovision Hierarchy) - Widespread motion capture interchange format
 - **ASF/AMC** (Acclaim) - A commonly used motion capture standard with explicit DOF specification
 
 **Research Standards:**
+
 - **HAnim** - Web3D Consortium humanoid animation specification
 - **SMPL/SMPL-X** - Statistical body model with extended facial/hand articulation
 
 **Engine Integrations:**
+
 - **Unreal Engine Mannequin** - Epic Games' reference skeleton with twist bone support
 - **Unity Mecanim** - Semantic humanoid mapping system
 - **General BVH** - Canonical motion capture representation
@@ -42,7 +45,7 @@ The analysis studies nine primary standards representing the current landscape o
 Each standard is examined across three dimensions:
 
 1. **Structural Analysis** - Joint count, hierarchical depth, optional components
-2. **Semantic Mapping** - Cross-format joint correspondence and naming patterns  
+2. **Semantic Mapping** - Cross-format joint correspondence and naming patterns
 3. **Technical Constraints** - Rotation orders, coordinate systems, channel specifications
 
 A unified mapping table provides direct semantic correspondence.
@@ -55,18 +58,18 @@ A unified mapping table provides direct semantic correspondence.
 
 ### Technical Context
 
-OpenUSD's humanoid skeletal representation is intended as an exemplar of Pixar's production-scale  character structure. The exemplar prioritizes comprehensive facial articulation and detailed extremity control, reflecting feature animation demands where subtle expression and gesture fidelity directly impact narrative effectiveness.
+OpenUSD's humanoid skeletal representation is intended as an exemplar of Pixar's production-scale character structure. The exemplar prioritizes comprehensive facial articulation and detailed extremity control, reflecting feature animation demands where subtle expression and gesture fidelity directly impact narrative effectiveness.
 
 The OpenUSD skeleton demonstrates strong architectural alignment with traditional animation workflows. Joint naming follows descriptive conventions that balance human readability with systematic processing, a critical consideration for pipeline tools that generalize and operate across multiple content creation applications.
 
 ### Hierarchical Structure
 
 ```
-  ___                _   _ ___ ___  
- / _ \ _ __  ___ _ _| | | / __|   \ 
+  ___                _   _ ___ ___
+ / _ \ _ __  ___ _ _| | | / __|   \
 | (_) | '_ \/ -_) ' \ |_| \__ \ |) |
- \___/| .__/\___|_||_\___/|___/___/ 
-      |_|       
+ \___/| .__/\___|_||_\___/|___/___/
+      |_|
 
 Hips
 ├── Torso
@@ -229,13 +232,12 @@ VRM's design philosophy emphasizes semantic consistency over naming flexibility�
 
 ## Hierarchical Structure
 
-
 ```
-__   _____ __  __ 
+__   _____ __  __
 \ \ / / _ \  \/  |
  \ V /|   / |\/| |
   \_/ |_|_\_|  |_|
-                  
+
 
 HumanoidRoot
 └─ Hips
@@ -341,11 +343,13 @@ VRM's core innovation lies in its semantic bone mapping system:
 VRM's semantic approach creates distinct advantages and challenges:
 
 **Strengths**:
+
 - **Automatic retargeting**: Semantic roles enable direct mapping to/from other humanoid standards
 - **Guaranteed compatibility**: Specification compliance ensures cross-application functionality
 - **Clear documentation**: Fixed bone roles eliminate interpretation ambiguity
 
 **Limitations**:
+
 - **Facial expression constraints**: Limited facial bone support requires blendshape-based or texture-based expression systems
 - **Custom rig integration**: Non-standard skeletal structures require manual mapping to VRM roles
 
@@ -383,11 +387,11 @@ HAnim's enduring relevance stems from its rigorous anatomical grounding and expl
 
 ```
 
- _  _   _        _       
-| || | /_\  _ _ (_)_ __  
-| __ |/ _ \| ' \| | '  \ 
+ _  _   _        _
+| || | /_\  _ _ (_)_ __
+| __ |/ _ \| ' \| | '  \
 |_||_/_/ \_\_||_|_|_|_|_|
-                         
+
 
 HumanoidRoot
  ├─ sacroiliac (pelvis/hip root)
@@ -495,11 +499,13 @@ HAnim's core strength lies in its anatomical correspondence:
 HAnim's anatomical precision creates specific mapping challenges:
 
 **Strengths**:
+
 - **Scientific foundation**: Anatomical accuracy provides authoritative mapping reference
 - **Comprehensive coverage**: Extended joint set accommodates detailed character requirements
 - **Clear specifications**: Explicit joint role definitions reduce mapping ambiguity
 
 **Challenges**:
+
 - **Nomenclature translation**: Medical terminology requires mapping to colloquial naming conventions
 - **Joint complexity**: Anatomical precision exceeds requirements for many application domains
 - **Implementation overhead**: Full specification compliance requires extensive joint support
@@ -556,15 +562,13 @@ This parametric approach enables SMPL-X to represent vast populations of human b
 
 ## Hierarchical Structure
 
-
-
 ```
 
  ___ __  __ ___ _     __  __
 / __|  \/  | _ \ |  __\ \/ /
-\__ \ |\/| |  _/ |_|___>  < 
+\__ \ |\/| |  _/ |_|___>  <
 |___/_|  |_|_| |____| /_/\_\
-                     
+
 pelvis
  ├── left_hip
  │    └── left_knee
@@ -671,11 +675,13 @@ The model's design explicitly addresses machine learning application requirement
 SMPL-X's research origins create distinct mapping characteristics:
 
 **Strengths**:
+
 - **Comprehensive coverage**: Unified body, hand, and face representation
 - **Statistical validity**: Population-based training ensures realistic human variation
 - **Computer vision compatibility**: Optimized for automated pose estimation and fitting
 
 **Challenges**:
+
 - **Non-standard naming**: Research-oriented joint identifiers require systematic translation
 - **Parameter dependencies**: Joint configurations coupled through statistical models rather than independent
 - **Artist workflow**: Parametric interface differs significantly from traditional animation controls
@@ -720,8 +726,8 @@ SMPL-X represents significant extensions over the original SMPL model:
 
 The SMPL-X framework represents a paradigm shift from artistic skeletal modeling toward data-driven human representation. This approach proves particularly valuable for applications requiring statistical validity, automated processing, and integration with machine learning pipelines where traditional animation-focused skeletons would introduce systematic biases or workflow incompatibilities.
 
-
 ---
+
 # BVH Motion Capture Standard
 
 ## Technical Context
@@ -734,14 +740,13 @@ BVH's architectural constraints emerge from its dual role as both skeletal defin
 
 ## Hierarchical Structure
 
-
 ```
 
- _____   ___  _ 
+ _____   ___  _
 | _ ) \ / / || |
 | _ \\ V /| __ |
 |___/ \_/ |_||_|
-                
+
 
 Hips
 ├─ Spine
@@ -833,11 +838,13 @@ BVH accommodates significant variation in implementation:
 BVH's flexibility creates both advantages and challenges for cross-format conversion:
 
 **Strengths**:
+
 - **Widespread compatibility**: Near-universal import support across animation and analysis tools
 - **Motion preservation**: Primary focus on temporal data maintains essential movement information
 - **Processing accessibility**: Text format enables custom parsing and conversion tools
 
 **Challenges**:
+
 - **Naming inconsistency**: Variable joint nomenclature requires intelligent mapping algorithms
 - **Skeletal variation**: Non-standard hierarchies complicate automated retargeting
 - **Unit ambiguity**: Undeclared measurement units cause scaling inconsistencies
@@ -883,6 +890,7 @@ The format's design balances functionality with practical constraints:
 The BVH format represents a pragmatic approach to motion data interchange—prioritizing practical utility and broad compatibility over theoretical completeness or optimal performance. This design philosophy has enabled BVH to serve as the de facto standard for motion capture data exchange across decades of technological evolution, demonstrating the enduring value of simple, flexible formats in complex production workflows.
 
 ---
+
 # ASF/AMC Motion Capture Standard
 
 ## Technical Context
@@ -895,12 +903,11 @@ ASF/AMC's influence extends far beyond its original research context through the
 
 ## Hierarchical Structure
 
-
 ```
 
-   _   ___ ___ ___   __  __  ___ 
+   _   ___ ___ ___   __  __  ___
   /_\ / __| __/ /_\ |  \/  |/ __|
- / _ \\__ \ _/ / _ \| |\/| | (__ 
+ / _ \\__ \ _/ / _ \| |\/| | (__
 /_/ \_\___/_/_/_/ \_\_|  |_|\___|
 
 pelvis
@@ -1004,11 +1011,13 @@ ASF files provide comprehensive skeletal definition through structured sections:
 ASF/AMC's academic precision creates specific advantages and challenges:
 
 **Strengths**:
+
 - **Parameter completeness**: Comprehensive skeletal specification eliminates ambiguity in cross-format conversion
 - **Mathematical consistency**: Precise geometric definitions enable accurate transformation calculations
 - **Documentation quality**: Text-based format supports detailed annotation and metadata preservation
 
 **Challenges**:
+
 - **Format complexity**: Complete parameter specification requires sophisticated parsing and validation
 - **Academic naming**: Biomechanical nomenclature may require translation for production workflows
 - **Processing overhead**: Comprehensive validation and parameter checking increases computational requirements
@@ -1075,14 +1084,13 @@ Mixamo's influence extends beyond its direct service offerings through its role 
 
 ## Hierarchical Structure
 
-
 ```
 
- __  __ _                    
-|  \/  (_)_ ____ _ _ __  ___ 
+ __  __ _
+|  \/  (_)_ ____ _ _ __  ___
 | |\/| | \ \ / _` | '  \/ _ \
 |_|  |_|_/_\_\__,_|_|_|_\___/
-                             
+
 
 Hips
 ├─ Spine
@@ -1154,11 +1162,13 @@ Mixamo's core innovation lies in its automated motion transfer capabilities:
 Mixamo's service-oriented design creates distinct mapping characteristics:
 
 **Strengths**:
+
 - **Broad compatibility**: Skeletal structure accommodates diverse input character formats
 - **Production integration**: Joint naming and hierarchy align with common animation software conventions
 - **Quality consistency**: Automated processing ensures reliable output across varied input quality
 
 **Challenges**:
+
 - **Service dependency**: Skeletal processing tied to Adobe's cloud infrastructure rather than open specifications
 - **Limited customization**: Automated workflows may not accommodate specialized rigging requirements
 - **Format lock-in**: Proprietary processing algorithms create dependencies on Mixamo ecosystem
@@ -1228,7 +1238,6 @@ Mixamo's development reflects broader industry trends:
 
 The Mixamo standard represents a service-oriented approach to character animation—prioritizing practical production utility and accessibility over theoretical completeness or maximum technical control. This design philosophy has democratized access to professional character animation while establishing skeletal conventions that balance automation requirements with artist workflow integration.
 
-
 ---
 
 # Unreal Engine Mannequin Skeleton
@@ -1243,14 +1252,13 @@ The skeleton's architectural foundation incorporates lessons learned from AAA ga
 
 ## Hierarchical Structure
 
-
 ```
 
- _   _ ___   ____  __                              _      
-| | | | __| / /  \/  |__ _ _ _  _ _  ___ __ _ _  _(_)_ _  
-| |_| | _| / /| |\/| / _` | ' \| ' \/ -_) _` | || | | ' \ 
+ _   _ ___   ____  __                              _
+| | | | __| / /  \/  |__ _ _ _  _ _  ___ __ _ _  _(_)_ _
+| |_| | _| / /| |\/| / _` | ' \| ' \/ -_) _` | || | | ' \
  \___/|___/_/ |_|  |_\__,_|_||_|_||_\___\__, |\_,_|_|_||_|
-                                           |_|                            
+                                           |_|
 
 Root (Pelvis)
 ├─ Spine_01
@@ -1323,11 +1331,13 @@ UE Mannequin addresses real-time deformation challenges through systematic desig
 The Mannequin's game-centric design creates specific mapping characteristics:
 
 **Strengths**:
+
 - **Production validation**: Extensive use in shipped games provides robust real-world validation
 - **Performance predictability**: Well-defined computational costs enable accurate performance budgeting
 - **Tool integration**: Native support within Unreal ecosystem reduces conversion overhead
 
 **Challenges**:
+
 - **Platform specificity**: Design optimizations may not translate effectively to other engine environments
 - **Naming conventions**: Game-oriented nomenclature may require translation for non-gaming applications
 - **Performance constraints**: Real-time limitations may exclude features required for offline rendering applications
@@ -1402,14 +1412,13 @@ Mecanim's influence extends beyond Unity's immediate ecosystem by establishing s
 
 ## Hierarchical Structure
 
-
 ```
 
- _   _      _ _          ____  __                  _       
-| | | |_ _ (_) |_ _  _  / /  \/  |___ __ __ _ _ _ (_)_ __  
-| |_| | ' \| |  _| || |/ /| |\/| / -_) _/ _` | ' \| | '  \ 
+ _   _      _ _          ____  __                  _
+| | | |_ _ (_) |_ _  _  / /  \/  |___ __ __ _ _ _ (_)_ __
+| |_| | ' \| |  _| || |/ /| |\/| / -_) _/ _` | ' \| | '  \
  \___/|_||_|_|\__|\_, /_/ |_|  |_\___\__\__,_|_||_|_|_|_|_|
-                  |__/                                     
+                  |__/
 
 Hips
 ├─ Spine
@@ -1482,11 +1491,13 @@ The system addresses practical animation reuse requirements:
 Mecanim's abstraction approach creates unique mapping characteristics:
 
 **Strengths**:
+
 - **Format agnostic**: Accepts arbitrary skeletal structures through semantic role assignment
 - **Animation portability**: Enables motion sharing across diverse character types and rigging approaches
 - **Artist accessibility**: Visual mapping interface reduces technical barriers for non-specialist users
 
 **Challenges**:
+
 - **Quality variability**: Retargeting results depend heavily on source skeleton appropriateness and mapping accuracy
 - **Performance overhead**: Runtime calculations required for cross-rig animation transfer
 - **Unity dependency**: Semantic mapping system tied to Unity engine rather than open standard
@@ -1556,96 +1567,96 @@ The system's accessibility has influenced game development practices:
 
 The Unity Mecanim system represents an abstraction-first approach to humanoid animation—prioritizing practical workflow benefits and cross-rig compatibility over structural standardization or maximum performance. This design philosophy has democratized advanced animation capabilities while establishing semantic role mapping as a viable alternative to traditional skeletal standardization approaches across the game development industry.
 
-
 ---
 
 ## **Unified Humanoid Skeleton Mapping Table**
 
-|CanonicalJoint         |OpenUSD                |BVH            |ASF/AMC           |VRM                    |HAnim       |SMPL    |SMPL-X       |Mixamo         |UEMannequin        |UnityMecanim    |FIELD12|
-|-----------------------|-----------------------|---------------|------------------|-----------------------|------------|--------|-------------|---------------|-------------------|----------------|-------|
-|Hips / Pelvis          |Hips                   |Hips           |pelvis            |hips                   |HumanoidRoot|pelvis  |pelvis       |Hips           |Root (Pelvis)      |Hips            |       |
-|Spine / LowerBack      |Torso                  |Spine          |lowerback         |spine                  |lumbosacral |spine1  |spine1       |Spine          |Spine_01           |Spine           |       |
-|Spine / Chest          |Chest                  |Spine1 / Spine2|upperback / thorax|chest                  |thorax      |spine2  |spine2       |Spine1 / Spine2|Spine_02 / Spine_03|Chest           |       |
-|UpperChest             |UpChest                |-              |-                 |upperChest             |opt         |-       |-            |-              |-                  |UpperChest (opt)|       |
-|Neck                   |Neck                   |Neck           |lowerneck         |neck                   |neck        |neck    |neck         |Neck           |Neck_01            |Neck            |       |
-|Head                   |Head                   |Head           |head              |head                   |head        |head    |head         |Head           |Head               |Head            |       |
-|Jaw                    |                       |EndSite        |opt               |jaw                    |opt         |opt     |jaw          |opt            |opt                |opt             |       |
-|LeftEye                |LEye                   |EndSite        |eye_l             |eye_l                  |eyeball_l   |-       |LEye         |opt            |Eye_L              |LeftEye         |       |
-|Left / Right Eyelids   |L / R controls x 12    |-              |-                 |-                      |-           |-       |-            |-              |-                  |-               |       |
-|LeftEyeTwist           |-                      |-              |-                 |-                      |-           |-       |LEyeTwist    |-              |Eye_L_Twist        |-               |       |
-|RightEye               |REye                   |EndSite        |eye_r             |eye_r                  |eyeball_r   |-       |REye         |opt            |Eye_R              |RightEye        |       |
-|RightEyeTwist          |-                      |-              |-                 |-                      |-           |-       |REyeTwist    |-              |Eye_R_Twist        |-               |       |
-|Nose                   |Nose                   |-              |-                 |nose                   |opt         |-       |Nose         |opt            |opt                |-               |       |
-|Chin                   |Chin / LChin / RChin   |-              |-                 |chin                   |opt         |-       |Chin         |opt            |opt                |-               |       |
-|Left / Right Ear       |LEar / REar            |-              |-                 |-                      |-           |-       |-            |-              |-                  |-               |       |
-|LeftCheek              |LCheek                 |-              |-                 |leftCheek              |opt         |-       |LCheek       |opt            |opt                |-               |       |
-|RightCheek             |RCheek                 |-              |-                 |rightCheek             |opt         |-       |RCheek       |opt            |opt                |-               |       |
-|Mouth                  |Mouth                  |-              |-                 |mouth                  |opt         |-       |Mouth        |opt            |opt                |-               |       |
-|UpperLip               |UpLip / LUpLip / RUpLip|-              |-                 |upperLip               |opt         |-       |UpLip        |opt            |opt                |-               |       |
-|LowerLip               |LoLip / LLoLip / RLoLip|-              |-                 |lowerLip               |opt         |-       |LoLip        |opt            |opt                |-               |       |
-|LeftLipCorner          |LLipCorner             |-              |-                 |leftLipCorner          |opt         |-       |LLipCorner   |opt            |opt                |-               |       |
-|RightLipCorner         |RLipCorner             |-              |-                 |rightLipCorner         |opt         |-       |RLipCorner   |opt            |opt                |-               |       |
-|Brow                   |LBrow / Brow           |-              |-                 |brow                   |opt         |-       |LBrow / RBrow|opt            |opt                |-               |       |
-|LeftClavicle           |LShldr                 |LeftShoulder   |lclavicle         |leftShoulder           |clavicle_l  |LShldr  |LShldr       |LeftShoulder   |Clavicle_L         |LeftShoulder    |       |
-|LeftUpperArm           |LArm                   |LeftArm        |lhumerus          |leftUpperArm           |humerus_l   |LArm    |LArm         |LeftArm        |UpperArm_L         |LeftUpperArm    |       |
-|LeftLowerArm           |LElbow                 |LeftForeArm    |lradius           |leftLowerArm           |radius_l    |LForeArm|LForeArm     |LeftForeArm    |LowerArm_L         |LeftLowerArm    |       |
-|LeftHand               |LHand                  |LeftHand       |lwrist            |leftHand               |hand_l      |LHand   |LHand        |LeftHand       |Hand_L             |LeftHand        |       |
-|LeftThumbProximal      |LThumb                 |-              |lthumb            |leftThumbProximal      |opt         |-       |LThumb       |LThumb         |opt                |opt             |       |
-|LeftThumbIntermediate  |LThumbMid              |-              |-                 |leftThumbIntermediate  |opt         |-       |LThumbMid    |LThumbMid      |opt                |opt             |       |
-|LeftThumbDistal        |LThumbTip              |-              |-                 |leftThumbDistal        |opt         |-       |LThumbTip    |LThumbTip      |opt                |opt             |       |
-|LeftThumbTip           |LThumbEnd              |-              |-                 |leftThumbTip           |opt         |-       |LThumbEnd    |LThumbEnd      |opt                |opt             |       |
-|LeftIndexProximal      |LIndex                 |-              |lindex            |leftIndexProximal      |opt         |-       |LIndex       |LIndex         |opt                |opt             |       |
-|LeftIndexIntermediate  |LIndexMid              |-              |-                 |leftIndexIntermediate  |opt         |-       |LIndexMid    |LIndexMid      |opt                |opt             |       |
-|LeftIndexDistal        |LIndexTip              |-              |-                 |leftIndexDistal        |opt         |-       |LIndexTip    |LIndexTip      |opt                |opt             |       |
-|LeftIndexTip           |LIndexEnd              |-              |-                 |leftIndexTip           |opt         |-       |LIndexEnd    |LIndexEnd      |opt                |opt             |       |
-|LeftMiddleProximal     |LMiddle                |-              |-                 |leftMiddleProximal     |opt         |-       |LMiddle      |LMiddle        |opt                |opt             |       |
-|LeftMiddleIntermediate |LMiddleMid             |-              |lmiddle           |leftMiddleIntermediate |opt         |-       |LMiddleMid   |LMiddleMid     |opt                |opt             |       |
-|LeftMiddleDistal       |LMiddleTip             |-              |-                 |leftMiddleDistal       |opt         |-       |LMiddleTip   |LMiddleTip     |opt                |opt             |       |
-|LeftMiddleTip          |LMiddleEnd             |-              |-                 |leftMiddleTip          |opt         |-       |LMiddleEnd   |LMiddleEnd     |opt                |opt             |       |
-|LeftRingProximal       |LRing                  |-              |lring             |leftRingProximal       |opt         |-       |LRing        |LRing          |opt                |opt             |       |
-|LeftRingIntermediate   |LRingMid               |-              |-                 |leftRingIntermediate   |opt         |-       |LRingMid     |LRingMid       |opt                |opt             |       |
-|LeftRingDistal         |LRingTip               |-              |-                 |leftRingDistal         |opt         |-       |LRingTip     |LRingTip       |opt                |opt             |       |
-|LeftRingTip            |LRingEnd               |-              |-                 |leftRingTip            |opt         |-       |LRingEnd     |LRingEnd       |opt                |opt             |       |
-|LeftPinkyProximal      |LPinky                 |-              |lpinky            |leftPinkyProximal      |opt         |-       |LPinky       |LPinky         |opt                |opt             |       |
-|LeftPinkyIntermediate  |LPinkyMid              |-              |-                 |leftPinkyIntermediate  |opt         |-       |LPinkyMid    |LPinkyMid      |opt                |opt             |       |
-|LeftPinkyDistal        |LPinkyTip              |-              |-                 |leftPinkyDistal        |opt         |-       |LPinkyTip    |LPinkyTip      |opt                |opt             |       |
-|LeftPinkyTip           |LPinkyEnd              |-              |-                 |leftPinkyTip           |opt         |-       |LPinkyEnd    |LPinkyEnd      |opt                |opt             |       |
-|RightClavicle          |RShldr                 |RightShoulder  |rclavicle         |rightShoulder          |clavicle_r  |RShldr  |RShldr       |RightShoulder  |Clavicle_R         |RightShoulder   |       |
-|RightUpperArm          |RArm                   |RightArm       |rhumerus          |rightUpperArm          |humerus_r   |RArm    |RArm         |RightArm       |UpperArm_R         |RightUpperArm   |       |
-|RightLowerArm          |RElbow                 |RightForeArm   |rradius           |rightLowerArm          |radius_r    |RForeArm|RForeArm     |RightForeArm   |LowerArm_R         |RightLowerArm   |       |
-|RightHand              |RHand                  |RightHand      |rwrist            |rightHand              |hand_r      |RHand   |RHand        |RightHand      |Hand_R             |RightHand       |       |
-|RightThumbProximal     |RThumb                 |-              |rthumb            |rightThumbProximal     |opt         |-       |RThumb       |RThumb         |opt                |opt             |       |
-|RightThumbIntermediate |RThumbMid              |-              |-                 |rightThumbIntermediate |opt         |-       |RThumbMid    |RThumbMid      |opt                |opt             |       |
-|RightThumbDistal       |RThumTip               |-              |-                 |rightThumbDistal       |opt         |-       |RThumbTip    |RThumbTip      |opt                |opt             |       |
-|RightThumbTip          |RThumEnd               |-              |-                 |rightThumbTip          |opt         |-       |RThumbEnd    |RThumbEnd      |opt                |opt             |       |
-|RightIndexProximal     |RIndex                 |-              |rindex            |rightIndexProximal     |opt         |-       |RIndex       |RIndex         |opt                |opt             |       |
-|RightIndexIntermediate |RIndexMid              |-              |-                 |rightIndexIntermediate |opt         |-       |RIndexMid    |RIndexMid      |opt                |opt             |       |
-|RightIndexDistal       |RIndexTip              |-              |-                 |rightIndexDistal       |opt         |-       |RIndexTip    |RIndexTip      |opt                |opt             |       |
-|RightIndexTip          |RIndexEnd              |-              |-                 |rightIndexTip          |opt         |-       |RIndexEnd    |RIndexEnd      |opt                |opt             |       |
-|RightMiddleProximal    |RMiddle                |-              |rmiddle           |rightMiddleProximal    |opt         |-       |RMiddle      |RMiddle        |opt                |opt             |       |
-|RightMiddleIntermediate|RMiddleMid             |-              |-                 |rightMiddleIntermediate|opt         |-       |RMiddleMid   |RMiddleMid     |opt                |opt             |       |
-|RightMiddleDistal      |RMiddleTip             |-              |-                 |rightMiddleDistal      |opt         |-       |RMiddleTip   |RMiddleTip     |opt                |opt             |       |
-|RightMiddleTip         |RMiddleEnd             |-              |-                 |rightMiddleTip         |opt         |-       |RMiddleEnd   |RMiddleEnd     |opt                |opt             |       |
-|RightRingProximal      |RRing                  |-              |rring             |rightRingProximal      |opt         |-       |RRing        |RRing          |opt                |opt             |       |
-|RightRingIntermediate  |RRingMid               |-              |-                 |rightRingIntermediate  |opt         |-       |RRingMid     |RRingMid       |opt                |opt             |       |
-|RightRingDistal        |RRingTip               |-              |-                 |rightRingDistal        |opt         |-       |RRingTip     |RRingTip       |opt                |opt             |       |
-|RightRingTip           |RRingEnd               |-              |-                 |rightRingTip           |opt         |-       |RRingEnd     |RRingEnd       |opt                |opt             |       |
-|RightPinkyProximal     |RPinky                 |-              |rpinky            |rightPinkyProximal     |opt         |-       |RPinky       |RPinky         |opt                |opt             |       |
-|RightPinkyIntermediate |RPinkyMid              |-              |-                 |rightPinkyIntermediate |opt         |-       |RPinkyMid    |RPinkyMid      |opt                |opt             |       |
-|RightPinkyDistal       |RPinkyTip              |-              |-                 |rightPinkyDistal       |opt         |-       |RPinkyTip    |RPinkyTip      |opt                |opt             |       |
-|RightPinkyTip          |RPinkyEnd              |-              |-                 |rightPinkyTip          |opt         |-       |RPinkyEnd    |RPinkyEnd      |opt                |opt             |       |
-|LeftUpperLeg           |LLeg                   |LeftUpLeg      |lfemur            |leftUpperLeg           |femur_l     |LThigh  |LThigh       |LeftUpLeg      |Thigh_L            |LeftUpperLeg    |       |
-|LeftLowerLeg           |LKnee                  |LeftLeg        |ltibia            |leftLowerLeg           |tibia_l     |LLeg    |LLeg         |LeftLeg        |Calf_L             |LeftLowerLeg    |       |
-|LeftFoot               |LFoot                  |LeftFoot       |lfoot             |leftFoot               |foot_l      |LFoot   |LFoot        |LeftFoot       |Foot_L             |LeftFoot        |       |
-|LeftToes               |LToes                  |EndSite        |ltoes             |leftToes               |opt         |-       |LeftToes     |LeftToeBase    |Toe_L (opt)        |LeftToes (opt)  |       |
-|LeftTip                |LTip                   |-              |-                 |leftTip                |opt         |-       |LTip         |-              |LeftTip (opt)      |                |       |
-|RightUpperLeg          |RLeg                   |RightUpLeg     |rfemur            |rightUpperLeg          |femur_r     |RThigh  |RThigh       |RightUpLeg     |Thigh_R            |RightUpperLeg   |       |
-|RightLowerLeg          |RKnee                  |RightLeg       |rtibia            |rightLowerLeg          |tibia_r     |RLeg    |RLeg         |RightLeg       |Calf_R             |RightLowerLeg   |       |
-|RightFoot              |RFoot                  |RightFoot      |rfoot             |rightFoot              |foot_r      |RFoot   |RFoot        |RightFoot      |Foot_R             |RightFoot       |       |
-|RightToes              |RToes                  |EndSite        |rtoes             |rightToes              |opt         |-       |RightToeBase |Toe_R (opt)    |RightToes (opt)    |                |       |
-|RightTip               |RTip                   |-              |-                 |rightTip               |opt         |-       |RTip         |-              |RightTip (opt)     |                |       |
+| CanonicalJoint          | OpenUSD                 | BVH             | ASF/AMC            | VRM                     | HAnim        | SMPL     | SMPL-X        | Mixamo          | UEMannequin         | UnityMecanim     | FIELD12 |
+| ----------------------- | ----------------------- | --------------- | ------------------ | ----------------------- | ------------ | -------- | ------------- | --------------- | ------------------- | ---------------- | ------- |
+| Hips / Pelvis           | Hips                    | Hips            | pelvis             | hips                    | HumanoidRoot | pelvis   | pelvis        | Hips            | Root (Pelvis)       | Hips             |         |
+| Spine / LowerBack       | Torso                   | Spine           | lowerback          | spine                   | lumbosacral  | spine1   | spine1        | Spine           | Spine_01            | Spine            |         |
+| Spine / Chest           | Chest                   | Spine1 / Spine2 | upperback / thorax | chest                   | thorax       | spine2   | spine2        | Spine1 / Spine2 | Spine_02 / Spine_03 | Chest            |         |
+| UpperChest              | UpChest                 | -               | -                  | upperChest              | opt          | -        | -             | -               | -                   | UpperChest (opt) |         |
+| Neck                    | Neck                    | Neck            | lowerneck          | neck                    | neck         | neck     | neck          | Neck            | Neck_01             | Neck             |         |
+| Head                    | Head                    | Head            | head               | head                    | head         | head     | head          | Head            | Head                | Head             |         |
+| Jaw                     |                         | EndSite         | opt                | jaw                     | opt          | opt      | jaw           | opt             | opt                 | opt              |         |
+| LeftEye                 | LEye                    | EndSite         | eye_l              | eye_l                   | eyeball_l    | -        | LEye          | opt             | Eye_L               | LeftEye          |         |
+| Left / Right Eyelids    | L / R controls x 12     | -               | -                  | -                       | -            | -        | -             | -               | -                   | -                |         |
+| LeftEyeTwist            | -                       | -               | -                  | -                       | -            | -        | LEyeTwist     | -               | Eye_L_Twist         | -                |         |
+| RightEye                | REye                    | EndSite         | eye_r              | eye_r                   | eyeball_r    | -        | REye          | opt             | Eye_R               | RightEye         |         |
+| RightEyeTwist           | -                       | -               | -                  | -                       | -            | -        | REyeTwist     | -               | Eye_R_Twist         | -                |         |
+| Nose                    | Nose                    | -               | -                  | nose                    | opt          | -        | Nose          | opt             | opt                 | -                |         |
+| Chin                    | Chin / LChin / RChin    | -               | -                  | chin                    | opt          | -        | Chin          | opt             | opt                 | -                |         |
+| Left / Right Ear        | LEar / REar             | -               | -                  | -                       | -            | -        | -             | -               | -                   | -                |         |
+| LeftCheek               | LCheek                  | -               | -                  | leftCheek               | opt          | -        | LCheek        | opt             | opt                 | -                |         |
+| RightCheek              | RCheek                  | -               | -                  | rightCheek              | opt          | -        | RCheek        | opt             | opt                 | -                |         |
+| Mouth                   | Mouth                   | -               | -                  | mouth                   | opt          | -        | Mouth         | opt             | opt                 | -                |         |
+| UpperLip                | UpLip / LUpLip / RUpLip | -               | -                  | upperLip                | opt          | -        | UpLip         | opt             | opt                 | -                |         |
+| LowerLip                | LoLip / LLoLip / RLoLip | -               | -                  | lowerLip                | opt          | -        | LoLip         | opt             | opt                 | -                |         |
+| LeftLipCorner           | LLipCorner              | -               | -                  | leftLipCorner           | opt          | -        | LLipCorner    | opt             | opt                 | -                |         |
+| RightLipCorner          | RLipCorner              | -               | -                  | rightLipCorner          | opt          | -        | RLipCorner    | opt             | opt                 | -                |         |
+| Brow                    | LBrow / Brow            | -               | -                  | brow                    | opt          | -        | LBrow / RBrow | opt             | opt                 | -                |         |
+| LeftClavicle            | LShldr                  | LeftShoulder    | lclavicle          | leftShoulder            | clavicle_l   | LShldr   | LShldr        | LeftShoulder    | Clavicle_L          | LeftShoulder     |         |
+| LeftUpperArm            | LArm                    | LeftArm         | lhumerus           | leftUpperArm            | humerus_l    | LArm     | LArm          | LeftArm         | UpperArm_L          | LeftUpperArm     |         |
+| LeftLowerArm            | LElbow                  | LeftForeArm     | lradius            | leftLowerArm            | radius_l     | LForeArm | LForeArm      | LeftForeArm     | LowerArm_L          | LeftLowerArm     |         |
+| LeftHand                | LHand                   | LeftHand        | lwrist             | leftHand                | hand_l       | LHand    | LHand         | LeftHand        | Hand_L              | LeftHand         |         |
+| LeftThumbProximal       | LThumb                  | -               | lthumb             | leftThumbProximal       | opt          | -        | LThumb        | LThumb          | opt                 | opt              |         |
+| LeftThumbIntermediate   | LThumbMid               | -               | -                  | leftThumbIntermediate   | opt          | -        | LThumbMid     | LThumbMid       | opt                 | opt              |         |
+| LeftThumbDistal         | LThumbTip               | -               | -                  | leftThumbDistal         | opt          | -        | LThumbTip     | LThumbTip       | opt                 | opt              |         |
+| LeftThumbTip            | LThumbEnd               | -               | -                  | leftThumbTip            | opt          | -        | LThumbEnd     | LThumbEnd       | opt                 | opt              |         |
+| LeftIndexProximal       | LIndex                  | -               | lindex             | leftIndexProximal       | opt          | -        | LIndex        | LIndex          | opt                 | opt              |         |
+| LeftIndexIntermediate   | LIndexMid               | -               | -                  | leftIndexIntermediate   | opt          | -        | LIndexMid     | LIndexMid       | opt                 | opt              |         |
+| LeftIndexDistal         | LIndexTip               | -               | -                  | leftIndexDistal         | opt          | -        | LIndexTip     | LIndexTip       | opt                 | opt              |         |
+| LeftIndexTip            | LIndexEnd               | -               | -                  | leftIndexTip            | opt          | -        | LIndexEnd     | LIndexEnd       | opt                 | opt              |         |
+| LeftMiddleProximal      | LMiddle                 | -               | -                  | leftMiddleProximal      | opt          | -        | LMiddle       | LMiddle         | opt                 | opt              |         |
+| LeftMiddleIntermediate  | LMiddleMid              | -               | lmiddle            | leftMiddleIntermediate  | opt          | -        | LMiddleMid    | LMiddleMid      | opt                 | opt              |         |
+| LeftMiddleDistal        | LMiddleTip              | -               | -                  | leftMiddleDistal        | opt          | -        | LMiddleTip    | LMiddleTip      | opt                 | opt              |         |
+| LeftMiddleTip           | LMiddleEnd              | -               | -                  | leftMiddleTip           | opt          | -        | LMiddleEnd    | LMiddleEnd      | opt                 | opt              |         |
+| LeftRingProximal        | LRing                   | -               | lring              | leftRingProximal        | opt          | -        | LRing         | LRing           | opt                 | opt              |         |
+| LeftRingIntermediate    | LRingMid                | -               | -                  | leftRingIntermediate    | opt          | -        | LRingMid      | LRingMid        | opt                 | opt              |         |
+| LeftRingDistal          | LRingTip                | -               | -                  | leftRingDistal          | opt          | -        | LRingTip      | LRingTip        | opt                 | opt              |         |
+| LeftRingTip             | LRingEnd                | -               | -                  | leftRingTip             | opt          | -        | LRingEnd      | LRingEnd        | opt                 | opt              |         |
+| LeftPinkyProximal       | LPinky                  | -               | lpinky             | leftPinkyProximal       | opt          | -        | LPinky        | LPinky          | opt                 | opt              |         |
+| LeftPinkyIntermediate   | LPinkyMid               | -               | -                  | leftPinkyIntermediate   | opt          | -        | LPinkyMid     | LPinkyMid       | opt                 | opt              |         |
+| LeftPinkyDistal         | LPinkyTip               | -               | -                  | leftPinkyDistal         | opt          | -        | LPinkyTip     | LPinkyTip       | opt                 | opt              |         |
+| LeftPinkyTip            | LPinkyEnd               | -               | -                  | leftPinkyTip            | opt          | -        | LPinkyEnd     | LPinkyEnd       | opt                 | opt              |         |
+| RightClavicle           | RShldr                  | RightShoulder   | rclavicle          | rightShoulder           | clavicle_r   | RShldr   | RShldr        | RightShoulder   | Clavicle_R          | RightShoulder    |         |
+| RightUpperArm           | RArm                    | RightArm        | rhumerus           | rightUpperArm           | humerus_r    | RArm     | RArm          | RightArm        | UpperArm_R          | RightUpperArm    |         |
+| RightLowerArm           | RElbow                  | RightForeArm    | rradius            | rightLowerArm           | radius_r     | RForeArm | RForeArm      | RightForeArm    | LowerArm_R          | RightLowerArm    |         |
+| RightHand               | RHand                   | RightHand       | rwrist             | rightHand               | hand_r       | RHand    | RHand         | RightHand       | Hand_R              | RightHand        |         |
+| RightThumbProximal      | RThumb                  | -               | rthumb             | rightThumbProximal      | opt          | -        | RThumb        | RThumb          | opt                 | opt              |         |
+| RightThumbIntermediate  | RThumbMid               | -               | -                  | rightThumbIntermediate  | opt          | -        | RThumbMid     | RThumbMid       | opt                 | opt              |         |
+| RightThumbDistal        | RThumTip                | -               | -                  | rightThumbDistal        | opt          | -        | RThumbTip     | RThumbTip       | opt                 | opt              |         |
+| RightThumbTip           | RThumEnd                | -               | -                  | rightThumbTip           | opt          | -        | RThumbEnd     | RThumbEnd       | opt                 | opt              |         |
+| RightIndexProximal      | RIndex                  | -               | rindex             | rightIndexProximal      | opt          | -        | RIndex        | RIndex          | opt                 | opt              |         |
+| RightIndexIntermediate  | RIndexMid               | -               | -                  | rightIndexIntermediate  | opt          | -        | RIndexMid     | RIndexMid       | opt                 | opt              |         |
+| RightIndexDistal        | RIndexTip               | -               | -                  | rightIndexDistal        | opt          | -        | RIndexTip     | RIndexTip       | opt                 | opt              |         |
+| RightIndexTip           | RIndexEnd               | -               | -                  | rightIndexTip           | opt          | -        | RIndexEnd     | RIndexEnd       | opt                 | opt              |         |
+| RightMiddleProximal     | RMiddle                 | -               | rmiddle            | rightMiddleProximal     | opt          | -        | RMiddle       | RMiddle         | opt                 | opt              |         |
+| RightMiddleIntermediate | RMiddleMid              | -               | -                  | rightMiddleIntermediate | opt          | -        | RMiddleMid    | RMiddleMid      | opt                 | opt              |         |
+| RightMiddleDistal       | RMiddleTip              | -               | -                  | rightMiddleDistal       | opt          | -        | RMiddleTip    | RMiddleTip      | opt                 | opt              |         |
+| RightMiddleTip          | RMiddleEnd              | -               | -                  | rightMiddleTip          | opt          | -        | RMiddleEnd    | RMiddleEnd      | opt                 | opt              |         |
+| RightRingProximal       | RRing                   | -               | rring              | rightRingProximal       | opt          | -        | RRing         | RRing           | opt                 | opt              |         |
+| RightRingIntermediate   | RRingMid                | -               | -                  | rightRingIntermediate   | opt          | -        | RRingMid      | RRingMid        | opt                 | opt              |         |
+| RightRingDistal         | RRingTip                | -               | -                  | rightRingDistal         | opt          | -        | RRingTip      | RRingTip        | opt                 | opt              |         |
+| RightRingTip            | RRingEnd                | -               | -                  | rightRingTip            | opt          | -        | RRingEnd      | RRingEnd        | opt                 | opt              |         |
+| RightPinkyProximal      | RPinky                  | -               | rpinky             | rightPinkyProximal      | opt          | -        | RPinky        | RPinky          | opt                 | opt              |         |
+| RightPinkyIntermediate  | RPinkyMid               | -               | -                  | rightPinkyIntermediate  | opt          | -        | RPinkyMid     | RPinkyMid       | opt                 | opt              |         |
+| RightPinkyDistal        | RPinkyTip               | -               | -                  | rightPinkyDistal        | opt          | -        | RPinkyTip     | RPinkyTip       | opt                 | opt              |         |
+| RightPinkyTip           | RPinkyEnd               | -               | -                  | rightPinkyTip           | opt          | -        | RPinkyEnd     | RPinkyEnd       | opt                 | opt              |         |
+| LeftUpperLeg            | LLeg                    | LeftUpLeg       | lfemur             | leftUpperLeg            | femur_l      | LThigh   | LThigh        | LeftUpLeg       | Thigh_L             | LeftUpperLeg     |         |
+| LeftLowerLeg            | LKnee                   | LeftLeg         | ltibia             | leftLowerLeg            | tibia_l      | LLeg     | LLeg          | LeftLeg         | Calf_L              | LeftLowerLeg     |         |
+| LeftFoot                | LFoot                   | LeftFoot        | lfoot              | leftFoot                | foot_l       | LFoot    | LFoot         | LeftFoot        | Foot_L              | LeftFoot         |         |
+| LeftToes                | LToes                   | EndSite         | ltoes              | leftToes                | opt          | -        | LeftToes      | LeftToeBase     | Toe_L (opt)         | LeftToes (opt)   |         |
+| LeftTip                 | LTip                    | -               | -                  | leftTip                 | opt          | -        | LTip          | -               | LeftTip (opt)       |                  |         |
+| RightUpperLeg           | RLeg                    | RightUpLeg      | rfemur             | rightUpperLeg           | femur_r      | RThigh   | RThigh        | RightUpLeg      | Thigh_R             | RightUpperLeg    |         |
+| RightLowerLeg           | RKnee                   | RightLeg        | rtibia             | rightLowerLeg           | tibia_r      | RLeg     | RLeg          | RightLeg        | Calf_R              | RightLowerLeg    |         |
+| RightFoot               | RFoot                   | RightFoot       | rfoot              | rightFoot               | foot_r       | RFoot    | RFoot         | RightFoot       | Foot_R              | RightFoot        |         |
+| RightToes               | RToes                   | EndSite         | rtoes              | rightToes               | opt          | -        | RightToeBase  | Toe_R (opt)     | RightToes (opt)     |                  |         |
+| RightTip                | RTip                    | -               | -                  | rightTip                | opt          | -        | RTip          | -               | RightTip (opt)      |                  |         |
 
 ---
+
 # Unified Humanoid Skeleton Mapping Table Analysis
 
 ## Methodological Foundation
@@ -1693,7 +1704,6 @@ Format pairs with similar complexity but different architectural approaches requ
 ---
 
 ## Reference Canonical Skeleton Framework
-
 
 ```
 Hips / Pelvis
@@ -1791,17 +1801,15 @@ Hips / Pelvis
                └─ RightTip (opt)
 ```
 
-
 ---
 
 ### **Legend**
 
-* `(opt)` = optional joint, not present in all skeleton standards
-* `(twist)` = twist bone, for improved deformation (UE Mannequin, SMPL-X)
-* Fingers and toes are fully segmented: proximal → intermediate → distal → tip
-* Facial and head joints fully enumerated for optional eyes, jaw, lips, cheeks
-* Root: Hips/Pelvis, all translations + rotations occur here
-
+- `(opt)` = optional joint, not present in all skeleton standards
+- `(twist)` = twist bone, for improved deformation (UE Mannequin, SMPL-X)
+- Fingers and toes are fully segmented: proximal → intermediate → distal → tip
+- Facial and head joints fully enumerated for optional eyes, jaw, lips, cheeks
+- Root: Hips/Pelvis, all translations + rotations occur here
 
 ## Architectural Foundation
 

--- a/survey.md
+++ b/survey.md
@@ -239,62 +239,62 @@ __   _____ __  __
   \_/ |_|_\_|  |_|
 
 
-HumanoidRoot
-└─ Hips
-   ├─ Spine
-   │  ├─ Chest
-   │  │  ├─ UpperChest [optional]
-   │  │  │  └─ Neck
-   │  │  │     └─ Head
-   │  │  │        ├─ LeftEye [optional]
+root [optional]
+└─ hips
+   ├─ spine
+   │  ├─ chest [optional]
+   │  │  ├─ upperChest [optional]
+   │  │  │  └─ neck [optional]
+   │  │  │     └─ head
+   │  │  │        ├─ leftEye [optional]
    │  │  │        ├─ RightEye [optional]
-   │  │  │        └─ Jaw [optional]
-   │  ├─ LeftShoulder [optional]
-   │  │  └─ LeftUpperArm
-   │  │     └─ LeftLowerArm
-   │  │        └─ LeftHand
-   │  │           ├─ LeftThumbProximal [optional]
-   │  │           │  └─ LeftThumbIntermediate [optional]
-   │  │           │     └─ LeftThumbDistal [optional]
-   │  │           ├─ LeftIndexProximal [optional]
-   │  │           │  └─ LeftIndexIntermediate [optional]
-   │  │           │     └─ LeftIndexDistal [optional]
-   │  │           ├─ LeftMiddleProximal [optional]
-   │  │           │  └─ LeftMiddleIntermediate [optional]
-   │  │           │     └─ LeftMiddleDistal [optional]
-   │  │           ├─ LeftRingProximal [optional]
-   │  │           │  └─ LeftRingIntermediate [optional]
-   │  │           │     └─ LeftRingDistal [optional]
-   │  │           └─ LeftLittleProximal [optional]
-   │  │              └─ LeftLittleIntermediate [optional]
-   │  │                 └─ LeftLittleDistal [optional]
-   │  └─ RightShoulder [optional]
-   │     └─ RightUpperArm
-   │        └─ RightLowerArm
-   │           └─ RightHand
-   │              ├─ RightThumbProximal [optional]
-   │              │  └─ RightThumbIntermediate [optional]
-   │              │     └─ RightThumbDistal [optional]
-   │              ├─ RightIndexProximal [optional]
-   │              │  └─ RightIndexIntermediate [optional]
-   │              │     └─ RightIndexDistal [optional]
-   │              ├─ RightMiddleProximal [optional]
-   │              │  └─ RightMiddleIntermediate [optional]
-   │              │     └─ RightMiddleDistal [optional]
-   │              ├─ RightRingProximal [optional]
-   │              │  └─ RightRingIntermediate [optional]
-   │              │     └─ RightRingDistal [optional]
-   │              └─ RightLittleProximal [optional]
-   │                 └─ RightLittleIntermediate [optional]
-   │                    └─ RightLittleDistal [optional]
-   ├─ LeftUpperLeg
-   │  └─ LeftLowerLeg
-   │     └─ LeftFoot
-   │        └─ LeftToes [optional]
-   └─ RightUpperLeg
-      └─ RightLowerLeg
-         └─ RightFoot
-            └─ RightToes [optional]
+   │  │  │        └─ jaw [optional]
+   │  ├─ leftShoulder [optional]
+   │  │  └─ leftUpperArm
+   │  │     └─ leftLowerArm
+   │  │        └─ leftHand
+   │  │           ├─ leftThumbMetacarpal [optional]
+   │  │           │  └─ leftThumbProximal [optional]
+   │  │           │     └─ leftThumbDistal [optional]
+   │  │           ├─ leftIndexProximal [optional]
+   │  │           │  └─ leftIndexIntermediate [optional]
+   │  │           │     └─ leftIndexDistal [optional]
+   │  │           ├─ leftMiddleProximal [optional]
+   │  │           │  └─ leftMiddleIntermediate [optional]
+   │  │           │     └─ leftMiddleDistal [optional]
+   │  │           ├─ leftRingProximal [optional]
+   │  │           │  └─ leftRingIntermediate [optional]
+   │  │           │     └─ leftRingDistal [optional]
+   │  │           └─ leftLittleProximal [optional]
+   │  │              └─ leftLittleIntermediate [optional]
+   │  │                 └─ leftLittleDistal [optional]
+   │  └─ rightShoulder [optional]
+   │     └─ rightUpperArm
+   │        └─ rightLowerArm
+   │           └─ rightHand
+   │              ├─ rightThumbMetacarpal [optional]
+   │              │  └─ rightThumbProximal [optional]
+   │              │     └─ rightThumbDistal [optional]
+   │              ├─ rightIndexProximal [optional]
+   │              │  └─ rightIndexIntermediate [optional]
+   │              │     └─ rightIndexDistal [optional]
+   │              ├─ rightMiddleProximal [optional]
+   │              │  └─ rightMiddleIntermediate [optional]
+   │              │     └─ rightMiddleDistal [optional]
+   │              ├─ rightRingProximal [optional]
+   │              │  └─ rightRingIntermediate [optional]
+   │              │     └─ rightRingDistal [optional]
+   │              └─ rightLittleProximal [optional]
+   │                 └─ rightLittleIntermediate [optional]
+   │                    └─ rightLittleDistal [optional]
+   ├─ leftUpperLeg
+   │  └─ leftLowerLeg
+   │     └─ leftFoot
+   │        └─ leftToes [optional]
+   └─ rightUpperLeg
+      └─ rightLowerLeg
+         └─ rightFoot
+            └─ rightToes [optional]
 
 Secondary (Spring) Bones [VRM extension nodes; optional and arbitrary]
 ├─ J_HairBack [example; arbitrary name]
@@ -311,7 +311,7 @@ Secondary (Spring) Bones [VRM extension nodes; optional and arbitrary]
 
 ## Architectural Analysis
 
-**Joint Count**: 55 standardized humanoid bones (24 required, 31 optional)
+**Joint Count**: 55 standardized humanoid bones (15 required, 41 optional)
 
 **Hierarchical Depth**: Maximum 9 levels (HumanoidRoot → Hips → Spine chains and extremity branches)
 
@@ -1432,12 +1432,40 @@ Hips
 │     │   └─ LeftUpperArm
 │     │       └─ LeftLowerArm
 │     │           └─ LeftHand
-│     │               └─ Fingers (optional)
+│     │               ├─ LeftThumbProximal
+│     │               │  └─ LeftThumbIntermediate
+│     │               │     └─ LeftThumbDistal
+│     │               ├─ LeftIndexProximal
+│     │               │  └─ LeftIndexIntermediate
+│     │               │     └─ LeftIndexDistal
+│     │               ├─ LeftMiddleProximal
+│     │               │  └─ LeftMiddleIntermediate
+│     │               │     └─ LeftMiddleDistal
+│     │               ├─ LeftRingProximal
+│     │               │  └─ LeftRingIntermediate
+│     │               │     └─ LeftRingDistal
+│     │               └─ LeftLittleProximal
+│     │                  └─ LeftLittleIntermediate
+│     │                    └─ LeftLittleDistal
 │     └─ RightShoulder
-│          └─ RightUpperArm
-│              └─ RightLowerArm
-│                  └─ RightHand
-│                      └─ Fingers (optional)
+│         └─ RightUpperArm
+│             └─ RightLowerArm
+│                 └─ RightHand
+│                     ├─ RightThumbProximal
+│                     │  └─ RightThumbIntermediate
+│                     │     └─ RightThumbDistal
+│                     ├─ RightIndexProximal
+│                     │  └─ RightIndexIntermediate
+│                     │     └─ RightIndexDistal
+│                     ├─ RightMiddleProximal
+│                     │  └─ RightMiddleIntermediate
+│                     │     └─ RightMiddleDistal
+│                     ├─ RightRingProximal
+│                     │  └─ RightRingIntermediate
+│                     │     └─ RightRingDistal
+│                     └─ RightLittleProximal
+│                        └─ RightLittleIntermediate
+│                          └─ RightLittleDistal
 ├─ LeftUpperLeg
 │   └─ LeftLowerLeg
 │       └─ LeftFoot
@@ -1447,6 +1475,8 @@ Hips
         └─ RightFoot
             └─ RightToes (optional)
 ```
+
+Note: Unity Mecanim's first two thumb bones use medically incorrect terminology.
 
 ## Architectural Analysis
 
@@ -1569,95 +1599,209 @@ The Unity Mecanim system represents an abstraction-first approach to humanoid an
 
 ---
 
-## **Unified Humanoid Skeleton Mapping Table**
+# Godot Engine SkeletonProfileHumanoid
 
-| CanonicalJoint          | OpenUSD                 | BVH             | ASF/AMC            | VRM                     | HAnim        | SMPL     | SMPL-X        | Mixamo          | UEMannequin         | UnityMecanim     | FIELD12 |
-| ----------------------- | ----------------------- | --------------- | ------------------ | ----------------------- | ------------ | -------- | ------------- | --------------- | ------------------- | ---------------- | ------- |
-| Hips / Pelvis           | Hips                    | Hips            | pelvis             | hips                    | HumanoidRoot | pelvis   | pelvis        | Hips            | Root (Pelvis)       | Hips             |         |
-| Spine / LowerBack       | Torso                   | Spine           | lowerback          | spine                   | lumbosacral  | spine1   | spine1        | Spine           | Spine_01            | Spine            |         |
-| Spine / Chest           | Chest                   | Spine1 / Spine2 | upperback / thorax | chest                   | thorax       | spine2   | spine2        | Spine1 / Spine2 | Spine_02 / Spine_03 | Chest            |         |
-| UpperChest              | UpChest                 | -               | -                  | upperChest              | opt          | -        | -             | -               | -                   | UpperChest (opt) |         |
-| Neck                    | Neck                    | Neck            | lowerneck          | neck                    | neck         | neck     | neck          | Neck            | Neck_01             | Neck             |         |
-| Head                    | Head                    | Head            | head               | head                    | head         | head     | head          | Head            | Head                | Head             |         |
-| Jaw                     |                         | EndSite         | opt                | jaw                     | opt          | opt      | jaw           | opt             | opt                 | opt              |         |
-| LeftEye                 | LEye                    | EndSite         | eye_l              | eye_l                   | eyeball_l    | -        | LEye          | opt             | Eye_L               | LeftEye          |         |
-| Left / Right Eyelids    | L / R controls x 12     | -               | -                  | -                       | -            | -        | -             | -               | -                   | -                |         |
-| LeftEyeTwist            | -                       | -               | -                  | -                       | -            | -        | LEyeTwist     | -               | Eye_L_Twist         | -                |         |
-| RightEye                | REye                    | EndSite         | eye_r              | eye_r                   | eyeball_r    | -        | REye          | opt             | Eye_R               | RightEye         |         |
-| RightEyeTwist           | -                       | -               | -                  | -                       | -            | -        | REyeTwist     | -               | Eye_R_Twist         | -                |         |
-| Nose                    | Nose                    | -               | -                  | nose                    | opt          | -        | Nose          | opt             | opt                 | -                |         |
-| Chin                    | Chin / LChin / RChin    | -               | -                  | chin                    | opt          | -        | Chin          | opt             | opt                 | -                |         |
-| Left / Right Ear        | LEar / REar             | -               | -                  | -                       | -            | -        | -             | -               | -                   | -                |         |
-| LeftCheek               | LCheek                  | -               | -                  | leftCheek               | opt          | -        | LCheek        | opt             | opt                 | -                |         |
-| RightCheek              | RCheek                  | -               | -                  | rightCheek              | opt          | -        | RCheek        | opt             | opt                 | -                |         |
-| Mouth                   | Mouth                   | -               | -                  | mouth                   | opt          | -        | Mouth         | opt             | opt                 | -                |         |
-| UpperLip                | UpLip / LUpLip / RUpLip | -               | -                  | upperLip                | opt          | -        | UpLip         | opt             | opt                 | -                |         |
-| LowerLip                | LoLip / LLoLip / RLoLip | -               | -                  | lowerLip                | opt          | -        | LoLip         | opt             | opt                 | -                |         |
-| LeftLipCorner           | LLipCorner              | -               | -                  | leftLipCorner           | opt          | -        | LLipCorner    | opt             | opt                 | -                |         |
-| RightLipCorner          | RLipCorner              | -               | -                  | rightLipCorner          | opt          | -        | RLipCorner    | opt             | opt                 | -                |         |
-| Brow                    | LBrow / Brow            | -               | -                  | brow                    | opt          | -        | LBrow / RBrow | opt             | opt                 | -                |         |
-| LeftClavicle            | LShldr                  | LeftShoulder    | lclavicle          | leftShoulder            | clavicle_l   | LShldr   | LShldr        | LeftShoulder    | Clavicle_L          | LeftShoulder     |         |
-| LeftUpperArm            | LArm                    | LeftArm         | lhumerus           | leftUpperArm            | humerus_l    | LArm     | LArm          | LeftArm         | UpperArm_L          | LeftUpperArm     |         |
-| LeftLowerArm            | LElbow                  | LeftForeArm     | lradius            | leftLowerArm            | radius_l     | LForeArm | LForeArm      | LeftForeArm     | LowerArm_L          | LeftLowerArm     |         |
-| LeftHand                | LHand                   | LeftHand        | lwrist             | leftHand                | hand_l       | LHand    | LHand         | LeftHand        | Hand_L              | LeftHand         |         |
-| LeftThumbProximal       | LThumb                  | -               | lthumb             | leftThumbProximal       | opt          | -        | LThumb        | LThumb          | opt                 | opt              |         |
-| LeftThumbIntermediate   | LThumbMid               | -               | -                  | leftThumbIntermediate   | opt          | -        | LThumbMid     | LThumbMid       | opt                 | opt              |         |
-| LeftThumbDistal         | LThumbTip               | -               | -                  | leftThumbDistal         | opt          | -        | LThumbTip     | LThumbTip       | opt                 | opt              |         |
-| LeftThumbTip            | LThumbEnd               | -               | -                  | leftThumbTip            | opt          | -        | LThumbEnd     | LThumbEnd       | opt                 | opt              |         |
-| LeftIndexProximal       | LIndex                  | -               | lindex             | leftIndexProximal       | opt          | -        | LIndex        | LIndex          | opt                 | opt              |         |
-| LeftIndexIntermediate   | LIndexMid               | -               | -                  | leftIndexIntermediate   | opt          | -        | LIndexMid     | LIndexMid       | opt                 | opt              |         |
-| LeftIndexDistal         | LIndexTip               | -               | -                  | leftIndexDistal         | opt          | -        | LIndexTip     | LIndexTip       | opt                 | opt              |         |
-| LeftIndexTip            | LIndexEnd               | -               | -                  | leftIndexTip            | opt          | -        | LIndexEnd     | LIndexEnd       | opt                 | opt              |         |
-| LeftMiddleProximal      | LMiddle                 | -               | -                  | leftMiddleProximal      | opt          | -        | LMiddle       | LMiddle         | opt                 | opt              |         |
-| LeftMiddleIntermediate  | LMiddleMid              | -               | lmiddle            | leftMiddleIntermediate  | opt          | -        | LMiddleMid    | LMiddleMid      | opt                 | opt              |         |
-| LeftMiddleDistal        | LMiddleTip              | -               | -                  | leftMiddleDistal        | opt          | -        | LMiddleTip    | LMiddleTip      | opt                 | opt              |         |
-| LeftMiddleTip           | LMiddleEnd              | -               | -                  | leftMiddleTip           | opt          | -        | LMiddleEnd    | LMiddleEnd      | opt                 | opt              |         |
-| LeftRingProximal        | LRing                   | -               | lring              | leftRingProximal        | opt          | -        | LRing         | LRing           | opt                 | opt              |         |
-| LeftRingIntermediate    | LRingMid                | -               | -                  | leftRingIntermediate    | opt          | -        | LRingMid      | LRingMid        | opt                 | opt              |         |
-| LeftRingDistal          | LRingTip                | -               | -                  | leftRingDistal          | opt          | -        | LRingTip      | LRingTip        | opt                 | opt              |         |
-| LeftRingTip             | LRingEnd                | -               | -                  | leftRingTip             | opt          | -        | LRingEnd      | LRingEnd        | opt                 | opt              |         |
-| LeftPinkyProximal       | LPinky                  | -               | lpinky             | leftPinkyProximal       | opt          | -        | LPinky        | LPinky          | opt                 | opt              |         |
-| LeftPinkyIntermediate   | LPinkyMid               | -               | -                  | leftPinkyIntermediate   | opt          | -        | LPinkyMid     | LPinkyMid       | opt                 | opt              |         |
-| LeftPinkyDistal         | LPinkyTip               | -               | -                  | leftPinkyDistal         | opt          | -        | LPinkyTip     | LPinkyTip       | opt                 | opt              |         |
-| LeftPinkyTip            | LPinkyEnd               | -               | -                  | leftPinkyTip            | opt          | -        | LPinkyEnd     | LPinkyEnd       | opt                 | opt              |         |
-| RightClavicle           | RShldr                  | RightShoulder   | rclavicle          | rightShoulder           | clavicle_r   | RShldr   | RShldr        | RightShoulder   | Clavicle_R          | RightShoulder    |         |
-| RightUpperArm           | RArm                    | RightArm        | rhumerus           | rightUpperArm           | humerus_r    | RArm     | RArm          | RightArm        | UpperArm_R          | RightUpperArm    |         |
-| RightLowerArm           | RElbow                  | RightForeArm    | rradius            | rightLowerArm           | radius_r     | RForeArm | RForeArm      | RightForeArm    | LowerArm_R          | RightLowerArm    |         |
-| RightHand               | RHand                   | RightHand       | rwrist             | rightHand               | hand_r       | RHand    | RHand         | RightHand       | Hand_R              | RightHand        |         |
-| RightThumbProximal      | RThumb                  | -               | rthumb             | rightThumbProximal      | opt          | -        | RThumb        | RThumb          | opt                 | opt              |         |
-| RightThumbIntermediate  | RThumbMid               | -               | -                  | rightThumbIntermediate  | opt          | -        | RThumbMid     | RThumbMid       | opt                 | opt              |         |
-| RightThumbDistal        | RThumTip                | -               | -                  | rightThumbDistal        | opt          | -        | RThumbTip     | RThumbTip       | opt                 | opt              |         |
-| RightThumbTip           | RThumEnd                | -               | -                  | rightThumbTip           | opt          | -        | RThumbEnd     | RThumbEnd       | opt                 | opt              |         |
-| RightIndexProximal      | RIndex                  | -               | rindex             | rightIndexProximal      | opt          | -        | RIndex        | RIndex          | opt                 | opt              |         |
-| RightIndexIntermediate  | RIndexMid               | -               | -                  | rightIndexIntermediate  | opt          | -        | RIndexMid     | RIndexMid       | opt                 | opt              |         |
-| RightIndexDistal        | RIndexTip               | -               | -                  | rightIndexDistal        | opt          | -        | RIndexTip     | RIndexTip       | opt                 | opt              |         |
-| RightIndexTip           | RIndexEnd               | -               | -                  | rightIndexTip           | opt          | -        | RIndexEnd     | RIndexEnd       | opt                 | opt              |         |
-| RightMiddleProximal     | RMiddle                 | -               | rmiddle            | rightMiddleProximal     | opt          | -        | RMiddle       | RMiddle         | opt                 | opt              |         |
-| RightMiddleIntermediate | RMiddleMid              | -               | -                  | rightMiddleIntermediate | opt          | -        | RMiddleMid    | RMiddleMid      | opt                 | opt              |         |
-| RightMiddleDistal       | RMiddleTip              | -               | -                  | rightMiddleDistal       | opt          | -        | RMiddleTip    | RMiddleTip      | opt                 | opt              |         |
-| RightMiddleTip          | RMiddleEnd              | -               | -                  | rightMiddleTip          | opt          | -        | RMiddleEnd    | RMiddleEnd      | opt                 | opt              |         |
-| RightRingProximal       | RRing                   | -               | rring              | rightRingProximal       | opt          | -        | RRing         | RRing           | opt                 | opt              |         |
-| RightRingIntermediate   | RRingMid                | -               | -                  | rightRingIntermediate   | opt          | -        | RRingMid      | RRingMid        | opt                 | opt              |         |
-| RightRingDistal         | RRingTip                | -               | -                  | rightRingDistal         | opt          | -        | RRingTip      | RRingTip        | opt                 | opt              |         |
-| RightRingTip            | RRingEnd                | -               | -                  | rightRingTip            | opt          | -        | RRingEnd      | RRingEnd        | opt                 | opt              |         |
-| RightPinkyProximal      | RPinky                  | -               | rpinky             | rightPinkyProximal      | opt          | -        | RPinky        | RPinky          | opt                 | opt              |         |
-| RightPinkyIntermediate  | RPinkyMid               | -               | -                  | rightPinkyIntermediate  | opt          | -        | RPinkyMid     | RPinkyMid       | opt                 | opt              |         |
-| RightPinkyDistal        | RPinkyTip               | -               | -                  | rightPinkyDistal        | opt          | -        | RPinkyTip     | RPinkyTip       | opt                 | opt              |         |
-| RightPinkyTip           | RPinkyEnd               | -               | -                  | rightPinkyTip           | opt          | -        | RPinkyEnd     | RPinkyEnd       | opt                 | opt              |         |
-| LeftUpperLeg            | LLeg                    | LeftUpLeg       | lfemur             | leftUpperLeg            | femur_l      | LThigh   | LThigh        | LeftUpLeg       | Thigh_L             | LeftUpperLeg     |         |
-| LeftLowerLeg            | LKnee                   | LeftLeg         | ltibia             | leftLowerLeg            | tibia_l      | LLeg     | LLeg          | LeftLeg         | Calf_L              | LeftLowerLeg     |         |
-| LeftFoot                | LFoot                   | LeftFoot        | lfoot              | leftFoot                | foot_l       | LFoot    | LFoot         | LeftFoot        | Foot_L              | LeftFoot         |         |
-| LeftToes                | LToes                   | EndSite         | ltoes              | leftToes                | opt          | -        | LeftToes      | LeftToeBase     | Toe_L (opt)         | LeftToes (opt)   |         |
-| LeftTip                 | LTip                    | -               | -                  | leftTip                 | opt          | -        | LTip          | -               | LeftTip (opt)       |                  |         |
-| RightUpperLeg           | RLeg                    | RightUpLeg      | rfemur             | rightUpperLeg           | femur_r      | RThigh   | RThigh        | RightUpLeg      | Thigh_R             | RightUpperLeg    |         |
-| RightLowerLeg           | RKnee                   | RightLeg        | rtibia             | rightLowerLeg           | tibia_r      | RLeg     | RLeg          | RightLeg        | Calf_R              | RightLowerLeg    |         |
-| RightFoot               | RFoot                   | RightFoot       | rfoot              | rightFoot               | foot_r       | RFoot    | RFoot         | RightFoot       | Foot_R              | RightFoot        |         |
-| RightToes               | RToes                   | EndSite         | rtoes              | rightToes               | opt          | -        | RightToeBase  | Toe_R (opt)     | RightToes (opt)     |                  |         |
-| RightTip                | RTip                    | -               | -                  | rightTip                | opt          | -        | RTip          | -               | RightTip (opt)      |                  |         |
+## Technical Context
+
+Godot Engine provides a [SkeletonProfile](https://docs.godotengine.org/en/stable/classes/class_skeletonprofile.html#class-skeletonprofile) class which allows skeletons to be retargeted from rigs found in 3D model files to a structure that the application recognizes for animation, kinematics, and other purposes.
+
+The [SkeletonProfileHumanoid](https://docs.godotengine.org/en/stable/classes/class_skeletonprofilehumanoid.html) class is a specialization of SkeletonProfile that defines a standard humanoid skeleton structure for use within Godot. This class defines names, parenting hierarchy, reference (T-pose) transforms, handles, groups, and whether the bones are required or optional for a valid humanoid skeleton.
+
+The [SkeletonProfileHumanoid](https://docs.godotengine.org/en/stable/classes/class_skeletonprofilehumanoid.html) class exists to serve the same purpose as VRM's humanoid skeleton and Unity Mecanim's humanoid avatar system. In fact, Godot uses the same exact names as VRM, except that VRM bones begin with a lowercase letter, while Godot bones begin with an uppercase letter. The names are also highly similar to Unity Mecanim, except that Godot adds a "Root" bone as the parent of "Hips", and the thumb bones use medically correct terminology.
+
+## Hierarchical Structure
+
+```
+   ____           _       _
+  / ___| ___   __| | ___ | |_
+ | |  _ / _ \ / _` |/ _ \| __|
+ | |_| | (_) | (_) | (_) | |_
+  \____|\___/ \__,_|\___/ \__|
+
+Root
+└─ Hips
+    ├─ LeftUpperLeg
+    │  └─ LeftLowerLeg
+    │     └─ LeftFoot
+    │        └─ LeftToes
+    ├─ RightUpperLeg
+    │  └─ RightLowerLeg
+    │     └─ RightFoot
+    │        └─ RightToes
+    └─ Spine
+        └─ Chest
+            └─ UpperChest
+                ├─ Neck
+                │   └─ Head
+                │       ├─ Jaw
+                │       ├─ LeftEye
+                │       └─ RightEye
+                ├─ LeftShoulder
+                │  └─ LeftUpperArm
+                │     └─ LeftLowerArm
+                │        └─ LeftHand
+                │           ├─ LeftThumbMetacarpal
+                │           │  └─ LeftThumbProximal
+                │           │    └─ LeftThumbDistal
+                │           ├─ LeftIndexProximal
+                │           │  └─ LeftIndexIntermediate
+                │           │    └─ LeftIndexDistal
+                │           ├─ LeftMiddleProximal
+                │           │  └─ LeftMiddleIntermediate
+                │           │    └─ LeftMiddleDistal
+                │           ├─ LeftRingProximal
+                │           │  └─ LeftRingIntermediate
+                │           │    └─ LeftRingDistal
+                │           └─ LeftLittleProximal
+                │              └─ LeftLittleIntermediate
+                │                └─ LeftLittleDistal
+                └─ RightShoulder
+                   └─ RightUpperArm
+                      └─ RightLowerArm
+                         └─ RightHand
+                            ├─ RightThumbMetacarpal
+                            │  └─ RightThumbProximal
+                            │     └─ RightThumbDistal
+                            ├─ RightIndexProximal
+                            │  └─ RightIndexIntermediate
+                            │     └─ RightIndexDistal
+                            ├─ RightMiddleProximal
+                            │  └─ RightMiddleIntermediate
+                            │     └─ RightMiddleDistal
+                            ├─ RightRingProximal
+                            │  └─ RightRingIntermediate
+                            │     └─ RightRingDistal
+                            └─ RightLittleProximal
+                               └─ RightLittleIntermediate
+                                 └─ RightLittleDistal
+```
+
+## Architectural Analysis
+
+**Joint Count**: 56 semantic roles (17 required, 39 optional) with 55 of them being humanoid bones, plus 1 optional "Root" bone.
+
+**Hierarchical Depth**: Restriction that some bones are descendant of others, otherwise semantic abstraction by name.
+
+**Distinctive Characteristics**:
+
+- **Remapping capability**: Godot provides a [BoneMap](https://docs.godotengine.org/en/stable/classes/class_bonemap.html#class-bonemap) class for remapping arbitrary skeletons imported from 3D models into a [SkeletonProfile](https://docs.godotengine.org/en/stable/classes/class_skeletonprofile.html#class-skeletonprofile) such as [SkeletonProfileHumanoid](https://docs.godotengine.org/en/stable/classes/class_skeletonprofilehumanoid.html).
+
+**Technical Constraints**:
+
+- **Role coverage requirements**: Minimum 17 bones must be successfully mapped for validation.
+
+**Strengths**:
+
+- **Roles inferred by name**: Skeletons set up with the recommended bone names can be used as-is without remapping.
+- **Format agnostic**: Prefers skeletons with already conformant names, but accepts arbitrary skeletal structures through bone remapping.
+- **Animation portability**: Enables animation retargeting across skeletons using the same profile, such as the humanoid profile.
+- **Artist accessibility**: Visual mapping interface reduces technical barriers for non-specialist users.
+- **Similarity**: Uses the same bone names as VRM and similar names to Unity Mecanim, easing cross-tool workflows for existing models.
+
+**Challenges**:
+
+- **Editor-centric**: Bone remapping tooling is primarily focused on the editor, while runtime imports have less retargeting capabilities.
+- **Subresource reuse**: Godot can only import a single file as one thing. Models containing both animations and an avatar can only be imported as either a scene with embedded animations just for that model, or a library of animations reusable by other models, but not both at the same time.
+- **Object-oriented**: Godot's design is highly object-oriented, with hierarchy items having single purposes, such as being only a bone, only a mesh, only a camera, only a light, and so on. Importing avatars with many "components" attached to a single node is requires generating multiple nodes. 3D artists are recommended to keep different components on separate nodes when creating models to ensure Godot compatibility.
 
 ---
 
 # Unified Humanoid Skeleton Mapping Table Analysis
+
+## Unified Humanoid Skeleton Mapping Table
+
+| CanonicalJoint             | OpenUSD                 | BVH             | ASF/AMC            | VRM                     | HAnim        | SMPL     | SMPL-X        | Mixamo          | UEMannequin         | UnityMecanim            | Godot                   |
+| -------------------------- | ----------------------- | --------------- | ------------------ | ----------------------- | ------------ | -------- | ------------- | --------------- | ------------------- | ----------------------- | ----------------------- |
+| Root (Parent of e.g. Hips) | -                       | -               | -                  | root                    | -            | -        | -             | -               | -                   | -                       | Root                    |
+| Hips / Pelvis              | Hips                    | Hips            | pelvis             | hips                    | HumanoidRoot | pelvis   | pelvis        | Hips            | Root (Pelvis)       | Hips                    | Hips                    |
+| Spine / LowerBack          | Torso                   | Spine           | lowerback          | spine                   | lumbosacral  | spine1   | spine1        | Spine           | Spine_01            | Spine                   | Spine                   |
+| Spine / Chest              | Chest                   | Spine1 / Spine2 | upperback / thorax | chest                   | thorax       | spine2   | spine2        | Spine1 / Spine2 | Spine_02 / Spine_03 | Chest                   | Chest                   |
+| UpperChest                 | UpChest                 | -               | -                  | upperChest              | opt          | -        | -             | -               | -                   | UpperChest (opt)        | UpperChest              |
+| Neck                       | Neck                    | Neck            | lowerneck          | neck                    | neck         | neck     | neck          | Neck            | Neck_01             | Neck                    | Neck                    |
+| Head                       | Head                    | Head            | head               | head                    | head         | head     | head          | Head            | Head                | Head                    | Head                    |
+| Jaw                        | -                       | EndSite         | opt                | jaw                     | opt          | opt      | jaw           | opt             | opt                 | Jaw                     | Jaw                     |
+| LeftEye                    | LEye                    | EndSite         | eye_l              | leftEye                 | eyeball_l    | -        | LEye          | opt             | Eye_L               | LeftEye                 | LeftEye                 |
+| Left / Right Eyelids       | L / R controls x 12     | -               | -                  | -                       | -            | -        | -             | -               | -                   | -                       | -                       |
+| LeftEyeTwist               | -                       | -               | -                  | -                       | -            | -        | LEyeTwist     | -               | Eye_L_Twist         | -                       | -                       |
+| RightEye                   | REye                    | EndSite         | eye_r              | rightEye                | eyeball_r    | -        | REye          | opt             | Eye_R               | RightEye                | RightEye                |
+| RightEyeTwist              | -                       | -               | -                  | -                       | -            | -        | REyeTwist     | -               | Eye_R_Twist         | -                       | -                       |
+| Nose                       | Nose                    | -               | -                  | -                       | opt          | -        | Nose          | opt             | opt                 | -                       | -                       |
+| Chin                       | Chin / LChin / RChin    | -               | -                  | -                       | opt          | -        | Chin          | opt             | opt                 | -                       | -                       |
+| Left / Right Ear           | LEar / REar             | -               | -                  | -                       | -            | -        | -             | -               | -                   | -                       | -                       |
+| LeftCheek                  | LCheek                  | -               | -                  | -                       | opt          | -        | LCheek        | opt             | opt                 | -                       | -                       |
+| RightCheek                 | RCheek                  | -               | -                  | -                       | opt          | -        | RCheek        | opt             | opt                 | -                       | -                       |
+| Mouth                      | Mouth                   | -               | -                  | -                       | opt          | -        | Mouth         | opt             | opt                 | -                       | -                       |
+| UpperLip                   | UpLip / LUpLip / RUpLip | -               | -                  | -                       | opt          | -        | UpLip         | opt             | opt                 | -                       | -                       |
+| LowerLip                   | LoLip / LLoLip / RLoLip | -               | -                  | -                       | opt          | -        | LoLip         | opt             | opt                 | -                       | -                       |
+| LeftLipCorner              | LLipCorner              | -               | -                  | -                       | opt          | -        | LLipCorner    | opt             | opt                 | -                       | -                       |
+| RightLipCorner             | RLipCorner              | -               | -                  | -                       | opt          | -        | RLipCorner    | opt             | opt                 | -                       | -                       |
+| Brow                       | LBrow / Brow            | -               | -                  | -                       | opt          | -        | LBrow / RBrow | opt             | opt                 | -                       | -                       |
+| LeftClavicle               | LShldr                  | LeftShoulder    | lclavicle          | leftShoulder            | clavicle_l   | LShldr   | LShldr        | LeftShoulder    | Clavicle_L          | LeftShoulder            | LeftShoulder            |
+| LeftUpperArm               | LArm                    | LeftArm         | lhumerus           | leftUpperArm            | humerus_l    | LArm     | LArm          | LeftArm         | UpperArm_L          | LeftUpperArm            | LeftUpperArm            |
+| LeftLowerArm               | LElbow                  | LeftForeArm     | lradius            | leftLowerArm            | radius_l     | LForeArm | LForeArm      | LeftForeArm     | LowerArm_L          | LeftLowerArm            | LeftLowerArm            |
+| LeftHand                   | LHand                   | LeftHand        | lwrist             | leftHand                | hand_l       | LHand    | LHand         | LeftHand        | Hand_L              | LeftHand                | LeftHand                |
+| LeftThumbMetacarpal        | LThumb                  | -               | lthumb             | leftThumbMetacarpal     | opt          | -        | LThumb        | LThumb          | opt                 | LeftThumbProximal       | LeftThumbMetacarpal     |
+| LeftThumbProximal          | LThumbMid               | -               | -                  | leftThumbProximal       | opt          | -        | LThumbMid     | LThumbMid       | opt                 | LeftThumbIntermediate   | LeftThumbProximal       |
+| LeftThumbDistal            | LThumbTip               | -               | -                  | leftThumbDistal         | opt          | -        | LThumbTip     | LThumbTip       | opt                 | LeftThumbDistal         | LeftThumbDistal         |
+| LeftThumbTip               | LThumbEnd               | -               | -                  | -                       | opt          | -        | LThumbEnd     | LThumbEnd       | opt                 | -                       | -                       |
+| LeftIndexMetacarpal        | -                       | -               | -                  | -                       | -            | -        | -             | -               | -                   | -                       | -                       |
+| LeftIndexProximal          | LIndex                  | -               | lindex             | leftIndexProximal       | opt          | -        | LIndex        | LIndex          | opt                 | LeftIndexProximal       | LeftIndexProximal       |
+| LeftIndexIntermediate      | LIndexMid               | -               | -                  | leftIndexIntermediate   | opt          | -        | LIndexMid     | LIndexMid       | opt                 | LeftIndexIntermediate   | LeftIndexIntermediate   |
+| LeftIndexDistal            | LIndexTip               | -               | -                  | leftIndexDistal         | opt          | -        | LIndexTip     | LIndexTip       | opt                 | LeftIndexDistal         | LeftIndexDistal         |
+| LeftIndexTip               | LIndexEnd               | -               | -                  | -                       | opt          | -        | LIndexEnd     | LIndexEnd       | opt                 | -                       | -                       |
+| LeftMiddleMetacarpal       | -                       | -               | -                  | -                       | -            | -        | -             | -               | -                   | -                       | -                       |
+| LeftMiddleProximal         | LMiddle                 | -               | -                  | leftMiddleProximal      | opt          | -        | LMiddle       | LMiddle         | opt                 | LeftMiddleProximal      | LeftMiddleProximal      |
+| LeftMiddleIntermediate     | LMiddleMid              | -               | lmiddle            | leftMiddleIntermediate  | opt          | -        | LMiddleMid    | LMiddleMid      | opt                 | LeftMiddleIntermediate  | LeftMiddleIntermediate  |
+| LeftMiddleDistal           | LMiddleTip              | -               | -                  | leftMiddleDistal        | opt          | -        | LMiddleTip    | LMiddleTip      | opt                 | LeftMiddleDistal        | LeftMiddleDistal        |
+| LeftMiddleTip              | LMiddleEnd              | -               | -                  | -                       | opt          | -        | LMiddleEnd    | LMiddleEnd      | opt                 | -                       | -                       |
+| LeftRingMetacarpal         | -                       | -               | -                  | -                       | -            | -        | -             | -               | -                   | -                       | -                       |
+| LeftRingProximal           | LRing                   | -               | lring              | leftRingProximal        | opt          | -        | LRing         | LRing           | opt                 | LeftRingProximal        | LeftRingProximal        |
+| LeftRingIntermediate       | LRingMid                | -               | -                  | leftRingIntermediate    | opt          | -        | LRingMid      | LRingMid        | opt                 | LeftRingIntermediate    | LeftRingIntermediate    |
+| LeftRingDistal             | LRingTip                | -               | -                  | leftRingDistal          | opt          | -        | LRingTip      | LRingTip        | opt                 | LeftRingDistal          | LeftRingDistal          |
+| LeftRingTip                | LRingEnd                | -               | -                  | -                       | opt          | -        | LRingEnd      | LRingEnd        | opt                 | -                       | -                       |
+| LeftPinkyMetacarpal        | -                       | -               | -                  | -                       | -            | -        | -             | -               | -                   | -                       | -                       |
+| LeftPinkyProximal          | LPinky                  | -               | lpinky             | leftLittleProximal      | opt          | -        | LPinky        | LPinky          | opt                 | LeftLittleProximal      | LeftLittleProximal      |
+| LeftPinkyIntermediate      | LPinkyMid               | -               | -                  | leftLittleIntermediate  | opt          | -        | LPinkyMid     | LPinkyMid       | opt                 | LeftLittleIntermediate  | LeftLittleIntermediate  |
+| LeftPinkyDistal            | LPinkyTip               | -               | -                  | leftLittleDistal        | opt          | -        | LPinkyTip     | LPinkyTip       | opt                 | LeftLittleDistal        | LeftLittleDistal        |
+| LeftPinkyTip               | LPinkyEnd               | -               | -                  | -                       | opt          | -        | LPinkyEnd     | LPinkyEnd       | opt                 | -                       | -                       |
+| RightClavicle              | RShldr                  | RightShoulder   | rclavicle          | rightShoulder           | clavicle_r   | RShldr   | RShldr        | RightShoulder   | Clavicle_R          | RightShoulder           | RightShoulder           |
+| RightUpperArm              | RArm                    | RightArm        | rhumerus           | rightUpperArm           | humerus_r    | RArm     | RArm          | RightArm        | UpperArm_R          | RightUpperArm           | RightUpperArm           |
+| RightLowerArm              | RElbow                  | RightForeArm    | rradius            | rightLowerArm           | radius_r     | RForeArm | RForeArm      | RightForeArm    | LowerArm_R          | RightLowerArm           | RightLowerArm           |
+| RightHand                  | RHand                   | RightHand       | rwrist             | rightHand               | hand_r       | RHand    | RHand         | RightHand       | Hand_R              | RightHand               | RightHand               |
+| RightThumbMetacarpal       | RThumb                  | -               | rthumb             | rightThumbMetacarpal    | opt          | -        | RThumb        | RThumb          | opt                 | RightThumbProximal      | RightThumbMetacarpal    |
+| RightThumbProximal         | RThumbMid               | -               | -                  | rightThumbProximal      | opt          | -        | RThumbMid     | RThumbMid       | opt                 | RightThumbIntermediate  | RightThumbProximal      |
+| RightThumbDistal           | RThumTip                | -               | -                  | rightThumbDistal        | opt          | -        | RThumbTip     | RThumbTip       | opt                 | RightThumbDistal        | RightThumbDistal        |
+| RightThumbTip              | RThumEnd                | -               | -                  | -                       | opt          | -        | RThumbEnd     | RThumbEnd       | opt                 | -                       | -                       |
+| RightIndexMetacarpal       | -                       | -               | -                  | -                       | -            | -        | -             | -               | -                   | -                       | -                       |
+| RightIndexProximal         | RIndex                  | -               | rindex             | rightIndexProximal      | opt          | -        | RIndex        | RIndex          | opt                 | RightIndexProximal      | RightIndexProximal      |
+| RightIndexIntermediate     | RIndexMid               | -               | -                  | rightIndexIntermediate  | opt          | -        | RIndexMid     | RIndexMid       | opt                 | RightIndexIntermediate  | RightIndexIntermediate  |
+| RightIndexDistal           | RIndexTip               | -               | -                  | rightIndexDistal        | opt          | -        | RIndexTip     | RIndexTip       | opt                 | RightIndexDistal        | RightIndexDistal        |
+| RightIndexTip              | RIndexEnd               | -               | -                  | -                       | opt          | -        | RIndexEnd     | RIndexEnd       | opt                 | -                       | -                       |
+| RightMiddleMetacarpal      | -                       | -               | -                  | -                       | -            | -        | -             | -               | -                   | -                       | -                       |
+| RightMiddleProximal        | RMiddle                 | -               | rmiddle            | rightMiddleProximal     | opt          | -        | RMiddle       | RMiddle         | opt                 | RightMiddleProximal     | RightMiddleProximal     |
+| RightMiddleIntermediate    | RMiddleMid              | -               | -                  | rightMiddleIntermediate | opt          | -        | RMiddleMid    | RMiddleMid      | opt                 | RightMiddleIntermediate | RightMiddleIntermediate |
+| RightMiddleDistal          | RMiddleTip              | -               | -                  | rightMiddleDistal       | opt          | -        | RMiddleTip    | RMiddleTip      | opt                 | RightMiddleDistal       | RightMiddleDistal       |
+| RightMiddleTip             | RMiddleEnd              | -               | -                  | -                       | opt          | -        | RMiddleEnd    | RMiddleEnd      | opt                 | -                       | -                       |
+| RightRingMetacarpal        | -                       | -               | -                  | -                       | -            | -        | -             | -               | -                   | -                       | -                       |
+| RightRingProximal          | RRing                   | -               | rring              | rightRingProximal       | opt          | -        | RRing         | RRing           | opt                 | RightRingProximal       | RightRingProximal       |
+| RightRingIntermediate      | RRingMid                | -               | -                  | rightRingIntermediate   | opt          | -        | RRingMid      | RRingMid        | opt                 | RightRingIntermediate   | RightRingIntermediate   |
+| RightRingDistal            | RRingTip                | -               | -                  | rightRingDistal         | opt          | -        | RRingTip      | RRingTip        | opt                 | RightRingDistal         | RightRingDistal         |
+| RightRingTip               | RRingEnd                | -               | -                  | -                       | opt          | -        | RRingEnd      | RRingEnd        | opt                 | -                       | -                       |
+| RightPinkyMetacarpal       | -                       | -               | -                  | -                       | -            | -        | -             | -               | -                   | -                       | -                       |
+| RightPinkyProximal         | RPinky                  | -               | rpinky             | rightLittleProximal     | opt          | -        | RPinky        | RPinky          | opt                 | RightLittleProximal     | RightLittleProximal     |
+| RightPinkyIntermediate     | RPinkyMid               | -               | -                  | rightLittleIntermediate | opt          | -        | RPinkyMid     | RPinkyMid       | opt                 | RightLittleIntermediate | RightLittleIntermediate |
+| RightPinkyDistal           | RPinkyTip               | -               | -                  | rightLittleDistal       | opt          | -        | RPinkyTip     | RPinkyTip       | opt                 | RightLittleDistal       | RightLittleDistal       |
+| RightPinkyTip              | RPinkyEnd               | -               | -                  | -                       | opt          | -        | RPinkyEnd     | RPinkyEnd       | opt                 | -                       | -                       |
+| LeftUpperLeg               | LLeg                    | LeftUpLeg       | lfemur             | leftUpperLeg            | femur_l      | LThigh   | LThigh        | LeftUpLeg       | Thigh_L             | LeftUpperLeg            | LeftUpperLeg            |
+| LeftLowerLeg               | LKnee                   | LeftLeg         | ltibia             | leftLowerLeg            | tibia_l      | LLeg     | LLeg          | LeftLeg         | Calf_L              | LeftLowerLeg            | LeftLowerLeg            |
+| LeftFoot                   | LFoot                   | LeftFoot        | lfoot              | leftFoot                | foot_l       | LFoot    | LFoot         | LeftFoot        | Foot_L              | LeftFoot                | LeftFoot                |
+| LeftToes                   | LToes                   | EndSite         | ltoes              | leftToes                | opt          | -        | LeftToes      | LeftToeBase     | Toe_L (opt)         | LeftToes (opt)          | LeftToes                |
+| LeftTip                    | LTip                    | -               | -                  | -                       | opt          | -        | LTip          | -               | LeftTip (opt)       | -                       | -                       |
+| RightUpperLeg              | RLeg                    | RightUpLeg      | rfemur             | rightUpperLeg           | femur_r      | RThigh   | RThigh        | RightUpLeg      | Thigh_R             | RightUpperLeg           | RightUpperLeg           |
+| RightLowerLeg              | RKnee                   | RightLeg        | rtibia             | rightLowerLeg           | tibia_r      | RLeg     | RLeg          | RightLeg        | Calf_R              | RightLowerLeg           | RightLowerLeg           |
+| RightFoot                  | RFoot                   | RightFoot       | rfoot              | rightFoot               | foot_r       | RFoot    | RFoot         | RightFoot       | Foot_R              | RightFoot               | RightFoot               |
+| RightToes                  | RToes                   | EndSite         | rtoes              | rightToes               | opt          | -        | -             | RightToeBase    | Toe_R (opt)         | RightToes (opt)         | RightToes               |
+| RightTip                   | RTip                    | -               | -                  | -                       | opt          | -        | RTip          | -               | RightTip (opt)      | -                       | -                       |
 
 ## Methodological Foundation
 
@@ -1735,60 +1879,68 @@ Hips / Pelvis
 │     │    └─ LeftUpperArm
 │     │         └─ LeftLowerArm
 │     │              └─ LeftHand
-│     │                   ├─ Thumb
-│     │                   │    ├─ ThumbProximal (opt / twist)
-│     │                   │    ├─ ThumbIntermediate (opt / twist)
-│     │                   │    ├─ ThumbDistal (opt / twist)
-│     │                   │    └─ ThumbTip (opt)
-│     │                   ├─ Index
-│     │                   │    ├─ IndexProximal (opt / twist)
-│     │                   │    ├─ IndexIntermediate (opt / twist)
-│     │                   │    ├─ IndexDistal (opt / twist)
-│     │                   │    └─ IndexTip (opt)
-│     │                   ├─ Middle
-│     │                   │    ├─ MiddleProximal (opt / twist)
-│     │                   │    ├─ MiddleIntermediate (opt / twist)
-│     │                   │    ├─ MiddleDistal (opt / twist)
-│     │                   │    └─ MiddleTip (opt)
-│     │                   ├─ Ring
-│     │                   │    ├─ RingProximal (opt / twist)
-│     │                   │    ├─ RingIntermediate (opt / twist)
-│     │                   │    ├─ RingDistal (opt / twist)
-│     │                   │    └─ RingTip (opt)
-│     │                   └─ Pinky
-│     │                        ├─ PinkyProximal (opt / twist)
-│     │                        ├─ PinkyIntermediate (opt / twist)
-│     │                        ├─ PinkyDistal (opt / twist)
-│     │                        └─ PinkyTip (opt)
+│     │                   ├─ LeftThumb
+│     │                   │    ├─ LeftThumbMetacarpal (opt / twist)
+│     │                   │    ├─ LeftThumbProximal (opt / twist)
+│     │                   │    ├─ LeftThumbDistal (opt / twist)
+│     │                   │    └─ LeftThumbTip (opt)
+│     │                   ├─ LeftIndex
+│     │                   │    ├─ LeftIndexMetacarpal (opt / uncommon)
+│     │                   │    ├─ LeftIndexProximal (opt / twist)
+│     │                   │    ├─ LeftIndexIntermediate (opt / twist)
+│     │                   │    ├─ LeftIndexDistal (opt / twist)
+│     │                   │    └─ LeftIndexTip (opt)
+│     │                   ├─ LeftMiddle
+│     │                   │    ├─ LeftMiddleMetacarpal (opt / uncommon)
+│     │                   │    ├─ LeftMiddleProximal (opt / twist)
+│     │                   │    ├─ LeftMiddleIntermediate (opt / twist)
+│     │                   │    ├─ LeftMiddleDistal (opt / twist)
+│     │                   │    └─ LeftMiddleTip (opt)
+│     │                   ├─ LeftRing
+│     │                   │    ├─ LeftRingMetacarpal (opt / uncommon)
+│     │                   │    ├─ LeftRingProximal (opt / twist)
+│     │                   │    ├─ LeftRingIntermediate (opt / twist)
+│     │                   │    ├─ LeftRingDistal (opt / twist)
+│     │                   │    └─ LeftRingTip (opt)
+│     │                   └─ LeftPinky
+│     │                        ├─ LeftPinkyMetacarpal (opt / uncommon)
+│     │                        ├─ LeftPinkyProximal (opt / twist)
+│     │                        ├─ LeftPinkyIntermediate (opt / twist)
+│     │                        ├─ LeftPinkyDistal (opt / twist)
+│     │                        └─ LeftPinkyTip (opt)
 │     └─ RightClavicle
 │          └─ RightUpperArm
 │               └─ RightLowerArm
 │                    └─ RightHand
-│                         ├─ Thumb
-│                         │    ├─ ThumbProximal (opt / twist)
-│                         │    ├─ ThumbIntermediate (opt / twist)
-│                         │    ├─ ThumbDistal (opt / twist)
-│                         │    └─ ThumbTip (opt)
-│                         ├─ Index
-│                         │    ├─ IndexProximal (opt / twist)
-│                         │    ├─ IndexIntermediate (opt / twist)
-│                         │    ├─ IndexDistal (opt / twist)
-│                         │    └─ IndexTip (opt)
-│                         ├─ Middle
-│                         │    ├─ MiddleProximal (opt / twist)
-│                         │    ├─ MiddleIntermediate (opt / twist)
-│                         │    ├─ MiddleDistal (opt / twist)
-│                         │    └─ MiddleTip (opt)
-│                         ├─ Ring
-│                         │    ├─ RingProximal (opt / twist)
-│                         │    ├─ RingIntermediate (opt / twist)
-│                         │    ├─ RingDistal (opt / twist)
-│                         │    └─ RingTip (opt)
-│                         └─ Pinky
-│                              ├─ PinkyProximal (opt / twist)
-│                              ├─ PinkyIntermediate (opt / twist)
-│                              ├─ PinkyDistal (opt / twist)
-│                              └─ PinkyTip (opt)
+│                         ├─ RightThumb
+│                         │    ├─ RightThumbMetacarpal (opt / twist)
+│                         │    ├─ RightThumbProximal (opt / twist)
+│                         │    ├─ RightThumbDistal (opt / twist)
+│                         │    └─ RightThumbTip (opt)
+│                         ├─ RightIndex
+│                         │    ├─ RightIndexMetacarpal (opt / uncommon)
+│                         │    ├─ RightIndexProximal (opt / twist)
+│                         │    ├─ RightIndexIntermediate (opt / twist)
+│                         │    ├─ RightIndexDistal (opt / twist)
+│                         │    └─ RightIndexTip (opt)
+│                         ├─ RightMiddle
+│                         │    ├─ RightMiddleMetacarpal (opt / uncommon)
+│                         │    ├─ RightMiddleProximal (opt / twist)
+│                         │    ├─ RightMiddleIntermediate (opt / twist)
+│                         │    ├─ RightMiddleDistal (opt / twist)
+│                         │    └─ RightMiddleTip (opt)
+│                         ├─ RightRing
+│                         │    ├─ RightRingMetacarpal (opt / uncommon)
+│                         │    ├─ RightRingProximal (opt / twist)
+│                         │    ├─ RightRingIntermediate (opt / twist)
+│                         │    ├─ RightRingDistal (opt / twist)
+│                         │    └─ RightRingTip (opt)
+│                         └─ RightPinky
+│                              ├─ RightPinkyMetacarpal (opt / uncommon)
+│                              ├─ RightPinkyProximal (opt / twist)
+│                              ├─ RightPinkyIntermediate (opt / twist)
+│                              ├─ RightPinkyDistal (opt / twist)
+│                              └─ RightPinkyTip (opt)
 ├─ LeftUpperLeg
 │    └─ LeftLowerLeg
 │         └─ LeftFoot
@@ -1888,86 +2040,95 @@ The comprehensive analysis demonstrates that humanoid skeletal interoperability 
 # APPENDIX A, Skeleton Table as CSV
 
 ```csv
-CanonicalJoint,OpenUSD,BVH,ASF/AMC,VRM,HAnim,SMPL,SMPL-X,Mixamo,UEMannequin,UnityMecanim,
-Hips / Pelvis,Hips,Hips,pelvis,hips,HumanoidRoot,pelvis,pelvis,Hips,Root (Pelvis),Hips,
-Spine / LowerBack,Torso,Spine,lowerback,spine,lumbosacral,spine1,spine1,Spine,Spine_01,Spine,
-Spine / Chest,Chest,Spine1 / Spine2,upperback / thorax,chest,thorax,spine2,spine2,Spine1 / Spine2,Spine_02 / Spine_03,Chest,
-UpperChest,UpChest,-,-,upperChest,opt,-,-,-,-,UpperChest (opt),
-Neck,Neck,Neck,lowerneck,neck,neck,neck,neck,Neck,Neck_01,Neck,
-Head,Head,Head,head,head,head,head,head,Head,Head,Head,
-Jaw,,EndSite,opt,jaw,opt,opt,jaw,opt,opt,opt,
-LeftEye,LEye,EndSite,eye_l,eye_l,eyeball_l,-,LEye,opt,Eye_L,LeftEye,
-Left / Right Eyelids,L / R controls x 12,-,-,-,-,-,-,-,-,-,
-LeftEyeTwist,-,-,-,-,-,-,LEyeTwist,-,Eye_L_Twist,-,
-RightEye,REye,EndSite,eye_r,eye_r,eyeball_r,-,REye,opt,Eye_R,RightEye,
-RightEyeTwist,-,-,-,-,-,-,REyeTwist,-,Eye_R_Twist,-,
-Nose,Nose,-,-,nose,opt,-,Nose,opt,opt,-,
-Chin,Chin / LChin / RChin,-,-,chin,opt,-,Chin,opt,opt,-,
-Left / Right Ear,LEar / REar,-,-,-,-,-,-,-,-,-,
-LeftCheek,LCheek,-,-,leftCheek,opt,-,LCheek,opt,opt,-,
-RightCheek,RCheek,-,-,rightCheek,opt,-,RCheek,opt,opt,-,
-Mouth,Mouth,-,-,mouth,opt,-,Mouth,opt,opt,-,
-UpperLip,UpLip / LUpLip / RUpLip,-,-,upperLip,opt,-,UpLip,opt,opt,-,
-LowerLip,LoLip / LLoLip / RLoLip,-,-,lowerLip,opt,-,LoLip,opt,opt,-,
-LeftLipCorner,LLipCorner,-,-,leftLipCorner,opt,-,LLipCorner,opt,opt,-,
-RightLipCorner,RLipCorner,-,-,rightLipCorner,opt,-,RLipCorner,opt,opt,-,
-Brow,LBrow / Brow,-,-,brow,opt,-,LBrow / RBrow,opt,opt,-,
-LeftClavicle,LShldr,LeftShoulder,lclavicle,leftShoulder,clavicle_l,LShldr,LShldr,LeftShoulder,Clavicle_L,LeftShoulder,
-LeftUpperArm,LArm,LeftArm,lhumerus,leftUpperArm,humerus_l,LArm,LArm,LeftArm,UpperArm_L,LeftUpperArm,
-LeftLowerArm,LElbow,LeftForeArm,lradius,leftLowerArm,radius_l,LForeArm,LForeArm,LeftForeArm,LowerArm_L,LeftLowerArm,
-LeftHand,LHand,LeftHand,lwrist,leftHand,hand_l,LHand,LHand,LeftHand,Hand_L,LeftHand,
-LeftThumbProximal,LThumb,-,lthumb,leftThumbProximal,opt,-,LThumb,LThumb,opt,opt,
-LeftThumbIntermediate,LThumbMid,-,-,leftThumbIntermediate,opt,-,LThumbMid,LThumbMid,opt,opt,
-LeftThumbDistal,LThumbTip,-,-,leftThumbDistal,opt,-,LThumbTip,LThumbTip,opt,opt,
-LeftThumbTip,LThumbEnd,-,-,leftThumbTip,opt,-,LThumbEnd,LThumbEnd,opt,opt,
-LeftIndexProximal,LIndex,-,lindex,leftIndexProximal,opt,-,LIndex,LIndex,opt,opt,
-LeftIndexIntermediate,LIndexMid,-,-,leftIndexIntermediate,opt,-,LIndexMid,LIndexMid,opt,opt,
-LeftIndexDistal,LIndexTip,-,-,leftIndexDistal,opt,-,LIndexTip,LIndexTip,opt,opt,
-LeftIndexTip,LIndexEnd,-,-,leftIndexTip,opt,-,LIndexEnd,LIndexEnd,opt,opt,
-LeftMiddleProximal,LMiddle,-,-,leftMiddleProximal,opt,-,LMiddle,LMiddle,opt,opt,
-LeftMiddleIntermediate,LMiddleMid,-,lmiddle,leftMiddleIntermediate,opt,-,LMiddleMid,LMiddleMid,opt,opt,
-LeftMiddleDistal,LMiddleTip,-,-,leftMiddleDistal,opt,-,LMiddleTip,LMiddleTip,opt,opt,
-LeftMiddleTip,LMiddleEnd,-,-,leftMiddleTip,opt,-,LMiddleEnd,LMiddleEnd,opt,opt,
-LeftRingProximal,LRing,-,lring,leftRingProximal,opt,-,LRing,LRing,opt,opt,
-LeftRingIntermediate,LRingMid,-,-,leftRingIntermediate,opt,-,LRingMid,LRingMid,opt,opt,
-LeftRingDistal,LRingTip,-,-,leftRingDistal,opt,-,LRingTip,LRingTip,opt,opt,
-LeftRingTip,LRingEnd,-,-,leftRingTip,opt,-,LRingEnd,LRingEnd,opt,opt,
-LeftPinkyProximal,LPinky,-,lpinky,leftPinkyProximal,opt,-,LPinky,LPinky,opt,opt,
-LeftPinkyIntermediate,LPinkyMid,-,-,leftPinkyIntermediate,opt,-,LPinkyMid,LPinkyMid,opt,opt,
-LeftPinkyDistal,LPinkyTip,-,-,leftPinkyDistal,opt,-,LPinkyTip,LPinkyTip,opt,opt,
-LeftPinkyTip,LPinkyEnd,-,-,leftPinkyTip,opt,-,LPinkyEnd,LPinkyEnd,opt,opt,
-RightClavicle,RShldr,RightShoulder,rclavicle,rightShoulder,clavicle_r,RShldr,RShldr,RightShoulder,Clavicle_R,RightShoulder,
-RightUpperArm,RArm,RightArm,rhumerus,rightUpperArm,humerus_r,RArm,RArm,RightArm,UpperArm_R,RightUpperArm,
-RightLowerArm,RElbow,RightForeArm,rradius,rightLowerArm,radius_r,RForeArm,RForeArm,RightForeArm,LowerArm_R,RightLowerArm,
-RightHand,RHand,RightHand,rwrist,rightHand,hand_r,RHand,RHand,RightHand,Hand_R,RightHand,
-RightThumbProximal,RThumb,-,rthumb,rightThumbProximal,opt,-,RThumb,RThumb,opt,opt,
-RightThumbIntermediate,RThumbMid,-,-,rightThumbIntermediate,opt,-,RThumbMid,RThumbMid,opt,opt,
-RightThumbDistal,RThumTip,-,-,rightThumbDistal,opt,-,RThumbTip,RThumbTip,opt,opt,
-RightThumbTip,RThumEnd,-,-,rightThumbTip,opt,-,RThumbEnd,RThumbEnd,opt,opt,
-RightIndexProximal,RIndex,-,rindex,rightIndexProximal,opt,-,RIndex,RIndex,opt,opt,
-RightIndexIntermediate,RIndexMid,-,-,rightIndexIntermediate,opt,-,RIndexMid,RIndexMid,opt,opt,
-RightIndexDistal,RIndexTip,-,-,rightIndexDistal,opt,-,RIndexTip,RIndexTip,opt,opt,
-RightIndexTip,RIndexEnd,-,-,rightIndexTip,opt,-,RIndexEnd,RIndexEnd,opt,opt,
-RightMiddleProximal,RMiddle,-,rmiddle,rightMiddleProximal,opt,-,RMiddle,RMiddle,opt,opt,
-RightMiddleIntermediate,RMiddleMid,-,-,rightMiddleIntermediate,opt,-,RMiddleMid,RMiddleMid,opt,opt,
-RightMiddleDistal,RMiddleTip,-,-,rightMiddleDistal,opt,-,RMiddleTip,RMiddleTip,opt,opt,
-RightMiddleTip,RMiddleEnd,-,-,rightMiddleTip,opt,-,RMiddleEnd,RMiddleEnd,opt,opt,
-RightRingProximal,RRing,-,rring,rightRingProximal,opt,-,RRing,RRing,opt,opt,
-RightRingIntermediate,RRingMid,-,-,rightRingIntermediate,opt,-,RRingMid,RRingMid,opt,opt,
-RightRingDistal,RRingTip,-,-,rightRingDistal,opt,-,RRingTip,RRingTip,opt,opt,
-RightRingTip,RRingEnd,-,-,rightRingTip,opt,-,RRingEnd,RRingEnd,opt,opt,
-RightPinkyProximal,RPinky,-,rpinky,rightPinkyProximal,opt,-,RPinky,RPinky,opt,opt,
-RightPinkyIntermediate,RPinkyMid,-,-,rightPinkyIntermediate,opt,-,RPinkyMid,RPinkyMid,opt,opt,
-RightPinkyDistal,RPinkyTip,-,-,rightPinkyDistal,opt,-,RPinkyTip,RPinkyTip,opt,opt,
-RightPinkyTip,RPinkyEnd,-,-,rightPinkyTip,opt,-,RPinkyEnd,RPinkyEnd,opt,opt,
-LeftUpperLeg,LLeg,LeftUpLeg,lfemur,leftUpperLeg,femur_l,LThigh,LThigh,LeftUpLeg,Thigh_L,LeftUpperLeg,
-LeftLowerLeg,LKnee,LeftLeg,ltibia,leftLowerLeg,tibia_l,LLeg,LLeg,LeftLeg,Calf_L,LeftLowerLeg,
-LeftFoot,LFoot,LeftFoot,lfoot,leftFoot,foot_l,LFoot,LFoot,LeftFoot,Foot_L,LeftFoot,
-LeftToes,LToes,EndSite,ltoes,leftToes,opt,-,LeftToes,LeftToeBase,Toe_L (opt),LeftToes (opt),
-LeftTip,LTip,-,-,leftTip,opt,-,LTip,-,LeftTip (opt),,
-RightUpperLeg,RLeg,RightUpLeg,rfemur,rightUpperLeg,femur_r,RThigh,RThigh,RightUpLeg,Thigh_R,RightUpperLeg,
-RightLowerLeg,RKnee,RightLeg,rtibia,rightLowerLeg,tibia_r,RLeg,RLeg,RightLeg,Calf_R,RightLowerLeg,
-RightFoot,RFoot,RightFoot,rfoot,rightFoot,foot_r,RFoot,RFoot,RightFoot,Foot_R,RightFoot,
-RightToes,RToes,EndSite,rtoes,rightToes,opt,-,RightToeBase,Toe_R (opt),RightToes (opt),,
-RightTip,RTip,-,-,rightTip,opt,-,RTip,-,RightTip (opt),,
+CanonicalJoint,OpenUSD,BVH,ASF/AMC,VRM,HAnim,SMPL,SMPL-X,Mixamo,UEMannequin,UnityMecanim,Godot
+Root (Parent of e.g. Hips),-,-,-,root,-,-,-,-,-,-,Root
+Hips / Pelvis,Hips,Hips,pelvis,hips,HumanoidRoot,pelvis,pelvis,Hips,Root (Pelvis),Hips,Hips
+Spine / LowerBack,Torso,Spine,lowerback,spine,lumbosacral,spine1,spine1,Spine,Spine_01,Spine,Spine
+Spine / Chest,Chest,Spine1 / Spine2,upperback / thorax,chest,thorax,spine2,spine2,Spine1 / Spine2,Spine_02 / Spine_03,Chest,Chest
+UpperChest,UpChest,-,-,upperChest,opt,-,-,-,-,UpperChest (opt),UpperChest
+Neck,Neck,Neck,lowerneck,neck,neck,neck,neck,Neck,Neck_01,Neck,Neck
+Head,Head,Head,head,head,head,head,head,Head,Head,Head,Head
+Jaw,-,EndSite,opt,jaw,opt,opt,jaw,opt,opt,Jaw,Jaw
+LeftEye,LEye,EndSite,eye_l,leftEye,eyeball_l,-,LEye,opt,Eye_L,LeftEye,LeftEye
+Left / Right Eyelids,L / R controls x 12,-,-,-,-,-,-,-,-,-,-
+LeftEyeTwist,-,-,-,-,-,-,LEyeTwist,-,Eye_L_Twist,-,-
+RightEye,REye,EndSite,eye_r,rightEye,eyeball_r,-,REye,opt,Eye_R,RightEye,RightEye
+RightEyeTwist,-,-,-,-,-,-,REyeTwist,-,Eye_R_Twist,-,-
+Nose,Nose,-,-,-,opt,-,Nose,opt,opt,-,-
+Chin,Chin / LChin / RChin,-,-,-,opt,-,Chin,opt,opt,-,-
+Left / Right Ear,LEar / REar,-,-,-,-,-,-,-,-,-,-
+LeftCheek,LCheek,-,-,-,opt,-,LCheek,opt,opt,-,-
+RightCheek,RCheek,-,-,-,opt,-,RCheek,opt,opt,-,-
+Mouth,Mouth,-,-,-,opt,-,Mouth,opt,opt,-,-
+UpperLip,UpLip / LUpLip / RUpLip,-,-,-,opt,-,UpLip,opt,opt,-,-
+LowerLip,LoLip / LLoLip / RLoLip,-,-,-,opt,-,LoLip,opt,opt,-,-
+LeftLipCorner,LLipCorner,-,-,-,opt,-,LLipCorner,opt,opt,-,-
+RightLipCorner,RLipCorner,-,-,-,opt,-,RLipCorner,opt,opt,-,-
+Brow,LBrow / Brow,-,-,-,opt,-,LBrow / RBrow,opt,opt,-,-
+LeftClavicle,LShldr,LeftShoulder,lclavicle,leftShoulder,clavicle_l,LShldr,LShldr,LeftShoulder,Clavicle_L,LeftShoulder,LeftShoulder
+LeftUpperArm,LArm,LeftArm,lhumerus,leftUpperArm,humerus_l,LArm,LArm,LeftArm,UpperArm_L,LeftUpperArm,LeftUpperArm
+LeftLowerArm,LElbow,LeftForeArm,lradius,leftLowerArm,radius_l,LForeArm,LForeArm,LeftForeArm,LowerArm_L,LeftLowerArm,LeftLowerArm
+LeftHand,LHand,LeftHand,lwrist,leftHand,hand_l,LHand,LHand,LeftHand,Hand_L,LeftHand,LeftHand
+LeftThumbMetacarpal,LThumb,-,lthumb,leftThumbMetacarpal,opt,-,LThumb,LThumb,opt,LeftThumbProximal,LeftThumbMetacarpal
+LeftThumbProximal,LThumbMid,-,-,leftThumbProximal,opt,-,LThumbMid,LThumbMid,opt,LeftThumbIntermediate,LeftThumbProximal
+LeftThumbDistal,LThumbTip,-,-,leftThumbDistal,opt,-,LThumbTip,LThumbTip,opt,LeftThumbDistal,LeftThumbDistal
+LeftThumbTip,LThumbEnd,-,-,-,opt,-,LThumbEnd,LThumbEnd,opt,-,-
+LeftIndexMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+LeftIndexProximal,LIndex,-,lindex,leftIndexProximal,opt,-,LIndex,LIndex,opt,LeftIndexProximal,LeftIndexProximal
+LeftIndexIntermediate,LIndexMid,-,-,leftIndexIntermediate,opt,-,LIndexMid,LIndexMid,opt,LeftIndexIntermediate,LeftIndexIntermediate
+LeftIndexDistal,LIndexTip,-,-,leftIndexDistal,opt,-,LIndexTip,LIndexTip,opt,LeftIndexDistal,LeftIndexDistal
+LeftIndexTip,LIndexEnd,-,-,-,opt,-,LIndexEnd,LIndexEnd,opt,-,-
+LeftMiddleMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+LeftMiddleProximal,LMiddle,-,-,leftMiddleProximal,opt,-,LMiddle,LMiddle,opt,LeftMiddleProximal,LeftMiddleProximal
+LeftMiddleIntermediate,LMiddleMid,-,lmiddle,leftMiddleIntermediate,opt,-,LMiddleMid,LMiddleMid,opt,LeftMiddleIntermediate,LeftMiddleIntermediate
+LeftMiddleDistal,LMiddleTip,-,-,leftMiddleDistal,opt,-,LMiddleTip,LMiddleTip,opt,LeftMiddleDistal,LeftMiddleDistal
+LeftMiddleTip,LMiddleEnd,-,-,-,opt,-,LMiddleEnd,LMiddleEnd,opt,-,-
+LeftRingMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+LeftRingProximal,LRing,-,lring,leftRingProximal,opt,-,LRing,LRing,opt,LeftRingProximal,LeftRingProximal
+LeftRingIntermediate,LRingMid,-,-,leftRingIntermediate,opt,-,LRingMid,LRingMid,opt,LeftRingIntermediate,LeftRingIntermediate
+LeftRingDistal,LRingTip,-,-,leftRingDistal,opt,-,LRingTip,LRingTip,opt,LeftRingDistal,LeftRingDistal
+LeftRingTip,LRingEnd,-,-,-,opt,-,LRingEnd,LRingEnd,opt,-,-
+LeftPinkyMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+LeftPinkyProximal,LPinky,-,lpinky,leftLittleProximal,opt,-,LPinky,LPinky,opt,LeftLittleProximal,LeftLittleProximal
+LeftPinkyIntermediate,LPinkyMid,-,-,leftLittleIntermediate,opt,-,LPinkyMid,LPinkyMid,opt,LeftLittleIntermediate,LeftLittleIntermediate
+LeftPinkyDistal,LPinkyTip,-,-,leftLittleDistal,opt,-,LPinkyTip,LPinkyTip,opt,LeftLittleDistal,LeftLittleDistal
+LeftPinkyTip,LPinkyEnd,-,-,-,opt,-,LPinkyEnd,LPinkyEnd,opt,-,-
+RightClavicle,RShldr,RightShoulder,rclavicle,rightShoulder,clavicle_r,RShldr,RShldr,RightShoulder,Clavicle_R,RightShoulder,RightShoulder
+RightUpperArm,RArm,RightArm,rhumerus,rightUpperArm,humerus_r,RArm,RArm,RightArm,UpperArm_R,RightUpperArm,RightUpperArm
+RightLowerArm,RElbow,RightForeArm,rradius,rightLowerArm,radius_r,RForeArm,RForeArm,RightForeArm,LowerArm_R,RightLowerArm,RightLowerArm
+RightHand,RHand,RightHand,rwrist,rightHand,hand_r,RHand,RHand,RightHand,Hand_R,RightHand,RightHand
+RightThumbMetacarpal,RThumb,-,rthumb,rightThumbMetacarpal,opt,-,RThumb,RThumb,opt,RightThumbProximal,RightThumbMetacarpal
+RightThumbProximal,RThumbMid,-,-,rightThumbProximal,opt,-,RThumbMid,RThumbMid,opt,RightThumbIntermediate,RightThumbProximal
+RightThumbDistal,RThumTip,-,-,rightThumbDistal,opt,-,RThumbTip,RThumbTip,opt,RightThumbDistal,RightThumbDistal
+RightThumbTip,RThumEnd,-,-,-,opt,-,RThumbEnd,RThumbEnd,opt,-,-
+RightIndexMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+RightIndexProximal,RIndex,-,rindex,rightIndexProximal,opt,-,RIndex,RIndex,opt,RightIndexProximal,RightIndexProximal
+RightIndexIntermediate,RIndexMid,-,-,rightIndexIntermediate,opt,-,RIndexMid,RIndexMid,opt,RightIndexIntermediate,RightIndexIntermediate
+RightIndexDistal,RIndexTip,-,-,rightIndexDistal,opt,-,RIndexTip,RIndexTip,opt,RightIndexDistal,RightIndexDistal
+RightIndexTip,RIndexEnd,-,-,-,opt,-,RIndexEnd,RIndexEnd,opt,-,-
+RightMiddleMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+RightMiddleProximal,RMiddle,-,rmiddle,rightMiddleProximal,opt,-,RMiddle,RMiddle,opt,RightMiddleProximal,RightMiddleProximal
+RightMiddleIntermediate,RMiddleMid,-,-,rightMiddleIntermediate,opt,-,RMiddleMid,RMiddleMid,opt,RightMiddleIntermediate,RightMiddleIntermediate
+RightMiddleDistal,RMiddleTip,-,-,rightMiddleDistal,opt,-,RMiddleTip,RMiddleTip,opt,RightMiddleDistal,RightMiddleDistal
+RightMiddleTip,RMiddleEnd,-,-,-,opt,-,RMiddleEnd,RMiddleEnd,opt,-,-
+RightRingMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+RightRingProximal,RRing,-,rring,rightRingProximal,opt,-,RRing,RRing,opt,RightRingProximal,RightRingProximal
+RightRingIntermediate,RRingMid,-,-,rightRingIntermediate,opt,-,RRingMid,RRingMid,opt,RightRingIntermediate,RightRingIntermediate
+RightRingDistal,RRingTip,-,-,rightRingDistal,opt,-,RRingTip,RRingTip,opt,RightRingDistal,RightRingDistal
+RightRingTip,RRingEnd,-,-,-,opt,-,RRingEnd,RRingEnd,opt,-,-
+RightPinkyMetacarpal,-,-,-,-,-,-,-,-,-,-,-
+RightPinkyProximal,RPinky,-,rpinky,rightLittleProximal,opt,-,RPinky,RPinky,opt,RightLittleProximal,RightLittleProximal
+RightPinkyIntermediate,RPinkyMid,-,-,rightLittleIntermediate,opt,-,RPinkyMid,RPinkyMid,opt,RightLittleIntermediate,RightLittleIntermediate
+RightPinkyDistal,RPinkyTip,-,-,rightLittleDistal,opt,-,RPinkyTip,RPinkyTip,opt,RightLittleDistal,RightLittleDistal
+RightPinkyTip,RPinkyEnd,-,-,-,opt,-,RPinkyEnd,RPinkyEnd,opt,-,-
+LeftUpperLeg,LLeg,LeftUpLeg,lfemur,leftUpperLeg,femur_l,LThigh,LThigh,LeftUpLeg,Thigh_L,LeftUpperLeg,LeftUpperLeg
+LeftLowerLeg,LKnee,LeftLeg,ltibia,leftLowerLeg,tibia_l,LLeg,LLeg,LeftLeg,Calf_L,LeftLowerLeg,LeftLowerLeg
+LeftFoot,LFoot,LeftFoot,lfoot,leftFoot,foot_l,LFoot,LFoot,LeftFoot,Foot_L,LeftFoot,LeftFoot
+LeftToes,LToes,EndSite,ltoes,leftToes,opt,-,LeftToes,LeftToeBase,Toe_L (opt),LeftToes (opt),LeftToes
+LeftTip,LTip,-,-,-,opt,-,LTip,-,LeftTip (opt),-,-
+RightUpperLeg,RLeg,RightUpLeg,rfemur,rightUpperLeg,femur_r,RThigh,RThigh,RightUpLeg,Thigh_R,RightUpperLeg,RightUpperLeg
+RightLowerLeg,RKnee,RightLeg,rtibia,rightLowerLeg,tibia_r,RLeg,RLeg,RightLeg,Calf_R,RightLowerLeg,RightLowerLeg
+RightFoot,RFoot,RightFoot,rfoot,rightFoot,foot_r,RFoot,RFoot,RightFoot,Foot_R,RightFoot,RightFoot
+RightToes,RToes,EndSite,rtoes,rightToes,opt,-,-,RightToeBase,Toe_R (opt),RightToes (opt),RightToes
+RightTip,RTip,-,-,-,opt,-,RTip,-,RightTip (opt),-,-
 ```


### PR DESCRIPTION
This PR has many changes that I made over the course of a few hours doing a detailed pass over this.

- Add information and mappings for Godot Engine [SkeletonProfileHumanoid](https://docs.godotengine.org/en/stable/classes/class_skeletonprofilehumanoid.html). This includes adding entries to the CSV, entires to the Markdown table, and lots of text to several files.
- Link to both [the VRM humanoid definition](https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0/humanoid.md) and Godot [SkeletonProfileHumanoid](https://docs.godotengine.org/en/stable/classes/class_skeletonprofilehumanoid.html) from the main README.md.
- Add missing finger bones for Unity Mecanim.
- Fix the canonical names of thumb bones to use medically correct terminology.
- Add metacarpal bones for all fingers. These medically exist, though they have a significantly constrained range of motion.
- Fix missing `-,` early in the toe tip bone CSV rows causing the rest of the rows to be one off.
- Remove empty `FIELD12` column from the survey Markdown table, and remove the trailing commas from the CSV causing CSV-to-Markdown converters to add such a field.
- Fix a LOT of issues with VRM. I don't know where you got this information from, but VRM does not define nose, cheek, mouth, lip, tip, or end bones at all, its eye bones are named `leftEye` and `rightEye`, all of its bones start with lowercase letters, its thumb bones use medically correct terminology, fixed which bones were marked as optional, and I think that's all the fixes...
- Mark VRM, Unity Mecanim, and Godot as validated in the main README.md.