### PR TITLE
Rename "LeftTip" to "LeftToesTip" and "RightTip" to "RightToesTip"

### DIFF
--- a/joints.csv
+++ b/joints.csv
@@ -83,9 +83,9 @@ LeftUpperLeg,LLeg,LeftUpLeg,lfemur,leftUpperLeg,femur_l,LThigh,LThigh,LeftUpLeg,
 LeftLowerLeg,LKnee,LeftLeg,ltibia,leftLowerLeg,tibia_l,LLeg,LLeg,LeftLeg,Calf_L,LeftLowerLeg,LeftLowerLeg
 LeftFoot,LFoot,LeftFoot,lfoot,leftFoot,foot_l,LFoot,LFoot,LeftFoot,Foot_L,LeftFoot,LeftFoot
 LeftToes,LToes,EndSite,ltoes,leftToes,opt,-,LeftToes,LeftToeBase,Toe_L (opt),LeftToes (opt),LeftToes
-LeftTip,LTip,-,-,-,opt,-,LTip,-,LeftTip (opt),-,-
+LeftToesTip,LTip,-,-,-,opt,-,LTip,-,LeftTip (opt),-,-
 RightUpperLeg,RLeg,RightUpLeg,rfemur,rightUpperLeg,femur_r,RThigh,RThigh,RightUpLeg,Thigh_R,RightUpperLeg,RightUpperLeg
 RightLowerLeg,RKnee,RightLeg,rtibia,rightLowerLeg,tibia_r,RLeg,RLeg,RightLeg,Calf_R,RightLowerLeg,RightLowerLeg
 RightFoot,RFoot,RightFoot,rfoot,rightFoot,foot_r,RFoot,RFoot,RightFoot,Foot_R,RightFoot,RightFoot
 RightToes,RToes,EndSite,rtoes,rightToes,opt,-,-,RightToeBase,Toe_R (opt),RightToes (opt),RightToes
-RightTip,RTip,-,-,-,opt,-,RTip,-,RightTip (opt),-,-
+RightToesTip,RTip,-,-,-,opt,-,RTip,-,RightTip (opt),-,-

--- a/proposal.md
+++ b/proposal.md
@@ -233,15 +233,15 @@ Hips / Pelvis (ROOT)
 │    └── LeftLowerLeg
 │         ├── LeftLowerLegTwist (opt / twist)
 │         └── LeftFoot
-│              ├── LeftToes (opt)
-│              └── LeftTip (opt)
+│              └── LeftToes (opt)
+│                   └── LeftToesTip (opt)
 └── RightUpperLeg
      ├── RightUpperLegTwist (opt / twist)
      └── RightLowerLeg
           ├── RightLowerLegTwist (opt / twist)
           └── RightFoot
-               ├── RightToes (opt)
-               └── RightTip (opt)
+               └── RightToes (opt)
+                    └── RightToesTip (opt)
 ```
 
 ## Joint Classification System

--- a/survey.md
+++ b/survey.md
@@ -1796,12 +1796,12 @@ Root
 | LeftLowerLeg               | LKnee                   | LeftLeg         | ltibia             | leftLowerLeg            | tibia_l      | LLeg     | LLeg          | LeftLeg         | Calf_L              | LeftLowerLeg            | LeftLowerLeg            |
 | LeftFoot                   | LFoot                   | LeftFoot        | lfoot              | leftFoot                | foot_l       | LFoot    | LFoot         | LeftFoot        | Foot_L              | LeftFoot                | LeftFoot                |
 | LeftToes                   | LToes                   | EndSite         | ltoes              | leftToes                | opt          | -        | LeftToes      | LeftToeBase     | Toe_L (opt)         | LeftToes (opt)          | LeftToes                |
-| LeftTip                    | LTip                    | -               | -                  | -                       | opt          | -        | LTip          | -               | LeftTip (opt)       | -                       | -                       |
+| LeftToesTip                | LTip                    | -               | -                  | -                       | opt          | -        | LTip          | -               | LeftTip (opt)       | -                       | -                       |
 | RightUpperLeg              | RLeg                    | RightUpLeg      | rfemur             | rightUpperLeg           | femur_r      | RThigh   | RThigh        | RightUpLeg      | Thigh_R             | RightUpperLeg           | RightUpperLeg           |
 | RightLowerLeg              | RKnee                   | RightLeg        | rtibia             | rightLowerLeg           | tibia_r      | RLeg     | RLeg          | RightLeg        | Calf_R              | RightLowerLeg           | RightLowerLeg           |
 | RightFoot                  | RFoot                   | RightFoot       | rfoot              | rightFoot               | foot_r       | RFoot    | RFoot         | RightFoot       | Foot_R              | RightFoot               | RightFoot               |
 | RightToes                  | RToes                   | EndSite         | rtoes              | rightToes               | opt          | -        | -             | RightToeBase    | Toe_R (opt)         | RightToes (opt)         | RightToes               |
-| RightTip                   | RTip                    | -               | -                  | -                       | opt          | -        | RTip          | -               | RightTip (opt)      | -                       | -                       |
+| RightToesTip               | RTip                    | -               | -                  | -                       | opt          | -        | RTip          | -               | RightTip (opt)      | -                       | -                       |
 
 ## Methodological Foundation
 
@@ -1944,13 +1944,13 @@ Hips / Pelvis
 ├─ LeftUpperLeg
 │    └─ LeftLowerLeg
 │         └─ LeftFoot
-│              ├─ LeftToes (opt)
-│              └─ LeftTip (opt)
+│              └─ LeftToes (opt)
+│                   └─ LeftToesTip (opt)
 └─ RightUpperLeg
      └─ RightLowerLeg
           └─ RightFoot
-               ├─ RightToes (opt)
-               └─ RightTip (opt)
+               └─ RightToes (opt)
+                   └─ RightToesTip (opt)
 ```
 
 ---
@@ -2125,10 +2125,10 @@ LeftUpperLeg,LLeg,LeftUpLeg,lfemur,leftUpperLeg,femur_l,LThigh,LThigh,LeftUpLeg,
 LeftLowerLeg,LKnee,LeftLeg,ltibia,leftLowerLeg,tibia_l,LLeg,LLeg,LeftLeg,Calf_L,LeftLowerLeg,LeftLowerLeg
 LeftFoot,LFoot,LeftFoot,lfoot,leftFoot,foot_l,LFoot,LFoot,LeftFoot,Foot_L,LeftFoot,LeftFoot
 LeftToes,LToes,EndSite,ltoes,leftToes,opt,-,LeftToes,LeftToeBase,Toe_L (opt),LeftToes (opt),LeftToes
-LeftTip,LTip,-,-,-,opt,-,LTip,-,LeftTip (opt),-,-
+LeftToesTip,LTip,-,-,-,opt,-,LTip,-,LeftTip (opt),-,-
 RightUpperLeg,RLeg,RightUpLeg,rfemur,rightUpperLeg,femur_r,RThigh,RThigh,RightUpLeg,Thigh_R,RightUpperLeg,RightUpperLeg
 RightLowerLeg,RKnee,RightLeg,rtibia,rightLowerLeg,tibia_r,RLeg,RLeg,RightLeg,Calf_R,RightLowerLeg,RightLowerLeg
 RightFoot,RFoot,RightFoot,rfoot,rightFoot,foot_r,RFoot,RFoot,RightFoot,Foot_R,RightFoot,RightFoot
 RightToes,RToes,EndSite,rtoes,rightToes,opt,-,-,RightToeBase,Toe_R (opt),RightToes (opt),RightToes
-RightTip,RTip,-,-,-,opt,-,RTip,-,RightTip (opt),-,-
+RightToesTip,RTip,-,-,-,opt,-,RTip,-,RightTip (opt),-,-
 ```


### PR DESCRIPTION
These had terrible naming. Tip of what? At a minimum they should contain the word "Toe", but since they are the tip of "Toes" I think "ToesTip" is better than "ToeTip". This is consistent with "RightIndexTip" for the tip of the index finger.

I know the existing engines that have this bone use "LTip" and "LeftTip", but this is just too ambiguous to put in a standard...

This PR also fixes them not being indented further in the hierarchy compared to "Toes".